### PR TITLE
feat: add network utilities and constants to ZunoAPIClient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,3 +37,11 @@ export {
   createContractInfoQueryOptions,
   createNetworksQueryOptions,
 } from './core/ZunoAPIClient';
+
+// Network utilities & constants
+export {
+  SUPPORTED_NETWORKS,
+  getSupportedNetworkNames,
+  isSupportedNetwork,
+  type SupportedNetwork,
+} from './core/ZunoAPIClient';

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -21,10 +21,15 @@ export interface AbiEntity {
 export interface NetworkEntity {
   id: string;
   name: string;
+  slug: string;
   chainId: number;
-  rpcUrl: string;
-  blockExplorer: string;
-  isTestnet: boolean;
+  type: string;
+  rpcUrl?: string;
+  blockExplorer?: string;
+  isTestnet?: boolean;
+  isActive?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 /**


### PR DESCRIPTION
- Introduced SUPPORTED_NETWORKS constant for easy access to supported network names and their chain IDs.
- Added utility functions: getSupportedNetworkNames and isSupportedNetwork for network validation.
- Updated NetworkEntity interface to include new properties for enhanced network information.