### PR TITLE
fix: auto-create provider from rpcUrl and make DevTools resilient

### DIFF
--- a/src/core/ZunoSDK.ts
+++ b/src/core/ZunoSDK.ts
@@ -2,17 +2,17 @@
  * Main SDK class for Zuno Marketplace
  */
 
-import { QueryClient } from '@tanstack/react-query';
-import { ethers } from 'ethers';
-import { ZunoAPIClient } from './ZunoAPIClient';
-import { ContractRegistry } from './ContractRegistry';
-import { ExchangeModule } from '../modules/ExchangeModule';
-import { CollectionModule } from '../modules/CollectionModule';
-import { AuctionModule } from '../modules/AuctionModule';
-import { EventEmitter } from '../utils/events';
-import { ZunoSDKError, ErrorCodes } from '../utils/errors';
-import { ZunoLogger, createNoOpLogger, type Logger } from '../utils/logger';
-import type { ZunoSDKConfig, SDKOptions } from '../types/config';
+import { QueryClient } from "@tanstack/react-query";
+import { ethers } from "ethers";
+import { ZunoAPIClient } from "./ZunoAPIClient";
+import { ContractRegistry } from "./ContractRegistry";
+import { ExchangeModule } from "../modules/ExchangeModule";
+import { CollectionModule } from "../modules/CollectionModule";
+import { AuctionModule } from "../modules/AuctionModule";
+import { EventEmitter } from "../utils/events";
+import { ZunoSDKError, ErrorCodes } from "../utils/errors";
+import { ZunoLogger, createNoOpLogger, type Logger } from "../utils/logger";
+import type { ZunoSDKConfig, SDKOptions } from "../types/config";
 
 // Singleton instance (module-level private variable)
 let _singletonInstance: ZunoSDK | null = null;
@@ -53,11 +53,14 @@ export class ZunoSDK extends EventEmitter {
     // Backward compatibility: if debug=true, set logger level to 'debug'
     const loggerConfig = config.logger || {};
     if (config.debug && !loggerConfig.level) {
-      loggerConfig.level = 'debug';
+      loggerConfig.level = "debug";
     }
 
     // Create logger or no-op logger
-    if (loggerConfig.level === 'none' || (!loggerConfig.level && !config.debug)) {
+    if (
+      loggerConfig.level === "none" ||
+      (!loggerConfig.level && !config.debug)
+    ) {
       this.logger = createNoOpLogger();
     } else {
       const zunoLogger = new ZunoLogger(loggerConfig);
@@ -65,14 +68,14 @@ export class ZunoSDK extends EventEmitter {
       zunoLogger.setContext({
         network: config.network,
         apiUrl: config.apiUrl,
-        version: '1.1.5', // Will be updated dynamically
+        version: "1.1.5", // Will be updated dynamically
       });
       this.logger = zunoLogger;
     }
 
     // Log SDK initialization
-    this.logger.info('Zuno SDK initialized', {
-      module: 'SDK',
+    this.logger.info("Zuno SDK initialized", {
+      module: "SDK",
       data: {
         network: config.network,
         hasProvider: !!options?.provider,
@@ -81,10 +84,7 @@ export class ZunoSDK extends EventEmitter {
     });
 
     // Initialize API client
-    this.apiClient = new ZunoAPIClient(
-      config.apiKey,
-      config.apiUrl
-    );
+    this.apiClient = new ZunoAPIClient(config.apiKey, config.apiUrl);
 
     // Initialize or use provided QueryClient
     this.queryClient = options?.queryClient || this.createDefaultQueryClient();
@@ -95,19 +95,14 @@ export class ZunoSDK extends EventEmitter {
       this.queryClient
     );
 
-    // Set provider and signer if provided
-    if (options?.provider) {
-      this.provider = options.provider;
-    }
-
-    if (options?.signer) {
-      this.signer = options.signer;
-    }
+    // Set provider and signer
+    this.provider = options?.provider ?? this.createDefaultProvider(config);
+    this.signer = options?.signer;
 
     // Auto-prefetch essential ABIs for better performance
     this.prefetchEssentialABIs().catch((error) => {
-      this.logger.warn('Failed to prefetch essential ABIs', {
-        module: 'SDK',
+      this.logger.warn("Failed to prefetch essential ABIs", {
+        module: "SDK",
         data: { error: error.message },
       });
     });
@@ -120,7 +115,7 @@ export class ZunoSDK extends EventEmitter {
     if (!this._exchange) {
       // Create module-specific logger
       const moduleLogger = (this.logger as any).createModuleLogger
-        ? (this.logger as any).createModuleLogger('Exchange')
+        ? (this.logger as any).createModuleLogger("Exchange")
         : this.logger;
 
       this._exchange = new ExchangeModule(
@@ -144,7 +139,7 @@ export class ZunoSDK extends EventEmitter {
     if (!this._collection) {
       // Create module-specific logger
       const moduleLogger = (this.logger as any).createModuleLogger
-        ? (this.logger as any).createModuleLogger('Collection')
+        ? (this.logger as any).createModuleLogger("Collection")
         : this.logger;
 
       this._collection = new CollectionModule(
@@ -168,7 +163,7 @@ export class ZunoSDK extends EventEmitter {
     if (!this._auction) {
       // Create module-specific logger
       const moduleLogger = (this.logger as any).createModuleLogger
-        ? (this.logger as any).createModuleLogger('Auction')
+        ? (this.logger as any).createModuleLogger("Auction")
         : this.logger;
 
       this._auction = new AuctionModule(
@@ -192,9 +187,15 @@ export class ZunoSDK extends EventEmitter {
     if (!this._offers) {
       // Placeholder module for MVP
       this._offers = {
-        makeOffer: async () => { throw new Error('Offers module not implemented yet'); },
-        acceptOffer: async () => { throw new Error('Offers module not implemented yet'); },
-        cancelOffer: async () => { throw new Error('Offers module not implemented yet'); },
+        makeOffer: async () => {
+          throw new Error("Offers module not implemented yet");
+        },
+        acceptOffer: async () => {
+          throw new Error("Offers module not implemented yet");
+        },
+        cancelOffer: async () => {
+          throw new Error("Offers module not implemented yet");
+        },
       };
     }
 
@@ -208,9 +209,15 @@ export class ZunoSDK extends EventEmitter {
     if (!this._bundles) {
       // Placeholder module for MVP
       this._bundles = {
-        createBundle: async () => { throw new Error('Bundles module not implemented yet'); },
-        buyBundle: async () => { throw new Error('Bundles module not implemented yet'); },
-        cancelBundle: async () => { throw new Error('Bundles module not implemented yet'); },
+        createBundle: async () => {
+          throw new Error("Bundles module not implemented yet");
+        },
+        buyBundle: async () => {
+          throw new Error("Bundles module not implemented yet");
+        },
+        cancelBundle: async () => {
+          throw new Error("Bundles module not implemented yet");
+        },
       };
     }
 
@@ -237,10 +244,10 @@ export class ZunoSDK extends EventEmitter {
       this._auction.updateProvider(provider, signer);
     }
 
-    this.emit('providerUpdated', { provider, signer });
+    this.emit("providerUpdated", { provider, signer });
 
     if (this.config.debug) {
-      console.log('[ZunoSDK] Provider updated');
+      console.log("[ZunoSDK] Provider updated");
     }
   }
 
@@ -284,20 +291,23 @@ export class ZunoSDK extends EventEmitter {
    */
   async prefetchEssentialABIs(): Promise<void> {
     const essentialContracts = [
-      'ERC721NFTExchange',
-      'ERC721CollectionFactory',
-      'ERC1155CollectionFactory',
+      "ERC721NFTExchange",
+      "ERC721CollectionFactory",
+      "ERC1155CollectionFactory",
     ] as const;
 
     const networkId =
-      typeof this.config.network === 'number'
+      typeof this.config.network === "number"
         ? this.config.network.toString()
         : this.config.network;
 
-    await this.contractRegistry.prefetchABIs([...essentialContracts], networkId);
+    await this.contractRegistry.prefetchABIs(
+      [...essentialContracts],
+      networkId
+    );
 
     if (this.config.debug) {
-      console.log('[ZunoSDK] Essential ABIs prefetched');
+      console.log("[ZunoSDK] Essential ABIs prefetched");
     }
   }
 
@@ -306,25 +316,25 @@ export class ZunoSDK extends EventEmitter {
    */
   async prefetchABIs(): Promise<void> {
     const contractTypes = [
-      'ERC721NFTExchange',
-      'ERC1155NFTExchange',
-      'ERC721CollectionFactory',
-      'ERC1155CollectionFactory',
-      'EnglishAuction',
-      'DutchAuction',
-      'OfferManager',
-      'BundleMarketplace',
+      "ERC721NFTExchange",
+      "ERC1155NFTExchange",
+      "ERC721CollectionFactory",
+      "ERC1155CollectionFactory",
+      "EnglishAuction",
+      "DutchAuction",
+      "OfferManager",
+      "BundleMarketplace",
     ] as const;
 
     const networkId =
-      typeof this.config.network === 'number'
+      typeof this.config.network === "number"
         ? this.config.network.toString()
         : this.config.network;
 
     await this.contractRegistry.prefetchABIs([...contractTypes], networkId);
 
     if (this.config.debug) {
-      console.log('[ZunoSDK] ABIs prefetched');
+      console.log("[ZunoSDK] ABIs prefetched");
     }
   }
 
@@ -336,8 +346,17 @@ export class ZunoSDK extends EventEmitter {
     this.queryClient.clear();
 
     if (this.config.debug) {
-      console.log('[ZunoSDK] Cache cleared');
+      console.log("[ZunoSDK] Cache cleared");
     }
+  }
+
+  /**
+   * Create default provider from config
+   */
+  private createDefaultProvider(
+    config: ZunoSDKConfig
+  ): ethers.Provider | undefined {
+    return config.rpcUrl ? new ethers.JsonRpcProvider(config.rpcUrl) : undefined;
   }
 
   /**
@@ -345,23 +364,17 @@ export class ZunoSDK extends EventEmitter {
    */
   private validateConfig(config: ZunoSDKConfig): void {
     if (!config.apiKey) {
-      throw new ZunoSDKError(
-        ErrorCodes.MISSING_API_KEY,
-        'API key is required'
-      );
+      throw new ZunoSDKError(ErrorCodes.MISSING_API_KEY, "API key is required");
     }
 
     if (!config.network) {
-      throw new ZunoSDKError(
-        ErrorCodes.INVALID_NETWORK,
-        'Network is required'
-      );
+      throw new ZunoSDKError(ErrorCodes.INVALID_NETWORK, "Network is required");
     }
 
     // Validate network type
-    const validNetworks = ['mainnet', 'sepolia', 'polygon', 'arbitrum'];
+    const validNetworks = ["mainnet", "sepolia", "polygon", "arbitrum"];
     if (
-      typeof config.network === 'string' &&
+      typeof config.network === "string" &&
       !validNetworks.includes(config.network)
     ) {
       if (config.debug) {
@@ -386,7 +399,7 @@ export class ZunoSDK extends EventEmitter {
           retry: this.config.retryPolicy?.maxRetries || 3,
           retryDelay: (attemptIndex) => {
             const delay = this.config.retryPolicy?.initialDelay || 1000;
-            return this.config.retryPolicy?.backoff === 'exponential'
+            return this.config.retryPolicy?.backoff === "exponential"
               ? Math.min(delay * 2 ** attemptIndex, 30000)
               : delay * (attemptIndex + 1);
           },
@@ -429,7 +442,7 @@ export class ZunoSDK extends EventEmitter {
       if (!config) {
         throw new ZunoSDKError(
           ErrorCodes.INVALID_CONFIG,
-          'Config required for first getInstance call. Initialize with ZunoSDK.getInstance(config) first.'
+          "Config required for first getInstance call. Initialize with ZunoSDK.getInstance(config) first."
         );
       }
       _singletonInstance = new ZunoSDK(config);

--- a/src/devtools/ZunoDevTools.tsx
+++ b/src/devtools/ZunoDevTools.tsx
@@ -3,10 +3,10 @@
  * A floating panel for debugging SDK operations during development
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import type { Logger, LogMetadata } from '../utils/logger';
-import { useZuno } from '../react/provider/ZunoContextProvider';
+import { ZunoContext } from '../react/provider/ZunoContextProvider';
 
 export interface DevToolsConfig {
   /** Show transaction history panel */
@@ -220,8 +220,9 @@ const styles = {
 export function ZunoDevTools({ logger, config: userConfig }: ZunoDevToolsProps) {
   const config = { ...DEFAULT_CONFIG, ...userConfig };
 
-  // Get SDK and QueryClient from hooks
-  const sdk = useZuno();
+  // Get SDK from context (safe - returns null if not in provider)
+  const context = useContext(ZunoContext);
+  const sdk = context?.sdk;
   const queryClient = useQueryClient();
 
   const [collapsed, setCollapsed] = useState(config.defaultCollapsed);
@@ -232,7 +233,7 @@ export function ZunoDevTools({ logger, config: userConfig }: ZunoDevToolsProps) 
 
   // Intercept SDK logger automatically
   useEffect(() => {
-    const sdkLogger = logger || sdk.logger;
+    const sdkLogger = logger || sdk?.logger;
     if (!sdkLogger) return;
 
     let logId = 0;
@@ -294,9 +295,9 @@ export function ZunoDevTools({ logger, config: userConfig }: ZunoDevToolsProps) 
   const clearTransactions = () => setTransactions([]);
 
   // Get network info from SDK
-  const networkInfo = sdk.getConfig();
-  const hasProvider = !!sdk.getProvider();
-  const hasSigner = !!sdk.getSigner();
+  const networkInfo = sdk?.getConfig() ?? { network: 'unknown', apiKey: '' };
+  const hasProvider = !!sdk?.getProvider();
+  const hasSigner = !!sdk?.getSigner();
 
   if (collapsed) {
     return (


### PR DESCRIPTION
- ZunoSDK: create default provider from config.rpcUrl if provided
- ZunoDevTools: use useContext instead of useZuno to avoid throwing
- ZunoDevTools: handle missing SDK context gracefully with optional chaining