### PR TITLE
docs: add comprehensive JSDoc to all new public methods

### DIFF
--- a/src/modules/CollectionModule.ts
+++ b/src/modules/CollectionModule.ts
@@ -717,7 +717,35 @@ export class CollectionModule extends BaseModule {
   }
 
   /**
-   * Add addresses to collection allowlist
+   * Add addresses to collection allowlist for allowlist-only minting
+   *
+   * When allowlist mode is enabled, only addresses on the allowlist
+   * can mint NFTs from the collection. This is useful for whitelist
+   * sales and restricted access minting.
+   *
+   * @param collectionAddress - The collection contract address
+   * @param addresses - Array of wallet addresses to add (max 100)
+   *
+   * @returns Promise resolving to transaction receipt
+   *
+   * @throws {ZunoSDKError} INVALID_ADDRESS - If collection address is invalid
+   * @throws {ZunoSDKError} INVALID_AMOUNT - If addresses array is empty or exceeds 100
+   * @throws {ZunoSDKError} TRANSACTION_FAILED - If transaction fails
+   * @throws {ZunoSDKError} NOT_OWNER - If caller is not collection owner
+   *
+   * @example
+   * ```typescript
+   * // Add addresses to allowlist
+   * const { tx } = await sdk.collection.addToAllowlist(
+   *   "0x1234...",
+   *   [
+   *     "0xabc...", // User 1
+   *     "0xdef...", // User 2
+   *     "0x123...", // User 3
+   *   ]
+   * );
+   * console.log('Added to allowlist:', tx.transactionHash);
+   * ```
    */
   async addToAllowlist(
     collectionAddress: string,
@@ -747,6 +775,29 @@ export class CollectionModule extends BaseModule {
 
   /**
    * Remove addresses from collection allowlist
+   *
+   * Removes wallet addresses from the collection's allowlist. Removed
+   * addresses will no longer be able to mint when allowlist mode is enabled.
+   *
+   * @param collectionAddress - The collection contract address
+   * @param addresses - Array of wallet addresses to remove
+   *
+   * @returns Promise resolving to transaction receipt
+   *
+   * @throws {ZunoSDKError} INVALID_ADDRESS - If collection address is invalid
+   * @throws {ZunoSDKError} INVALID_AMOUNT - If addresses array is empty
+   * @throws {ZunoSDKError} TRANSACTION_FAILED - If transaction fails
+   * @throws {ZunoSDKError} NOT_OWNER - If caller is not collection owner
+   *
+   * @example
+   * ```typescript
+   * // Remove addresses from allowlist
+   * const { tx } = await sdk.collection.removeFromAllowlist(
+   *   "0x1234...",
+   *   ["0xabc...", "0xdef..."]
+   * );
+   * console.log('Removed from allowlist:', tx.transactionHash);
+   * ```
    */
   async removeFromAllowlist(
     collectionAddress: string,
@@ -772,7 +823,28 @@ export class CollectionModule extends BaseModule {
   }
 
   /**
-   * Set allowlist-only mode (disables public minting)
+   * Enable or disable allowlist-only minting mode for a collection
+   *
+   * When enabled, only addresses on the allowlist can mint NFTs.
+   * When disabled, anyone can mint NFTs (public minting).
+   *
+   * @param collectionAddress - The collection contract address
+   * @param enabled - True to enable allowlist mode, false to disable
+   *
+   * @returns Promise resolving to transaction receipt
+   *
+   * @throws {ZunoSDKError} INVALID_ADDRESS - If collection address is invalid
+   * @throws {ZunoSDKError} TRANSACTION_FAILED - If transaction fails
+   * @throws {ZunoSDKError} NOT_OWNER - If caller is not collection owner
+   *
+   * @example
+   * ```typescript
+   * // Enable allowlist-only mode
+   * await sdk.collection.setAllowlistOnly("0x1234...", true);
+   *
+   * // Disable allowlist-only mode (open public minting)
+   * await sdk.collection.setAllowlistOnly("0x1234...", false);
+   * ```
    */
   async setAllowlistOnly(
     collectionAddress: string,
@@ -795,7 +867,25 @@ export class CollectionModule extends BaseModule {
   }
 
   /**
-   * Check if address is in allowlist
+   * Check if an address is on the collection's allowlist
+   *
+   * @param collectionAddress - The collection contract address
+   * @param address - The wallet address to check
+   *
+   * @returns Promise resolving to true if address is on allowlist, false otherwise
+   *
+   * @throws {ZunoSDKError} INVALID_ADDRESS - If collection or address is invalid
+   *
+   * @example
+   * ```typescript
+   * const isAllowed = await sdk.collection.isInAllowlist(
+   *   "0x1234...",
+   *   "0xabc..."
+   * );
+   * if (isAllowed) {
+   *   console.log('Address can mint during allowlist phase');
+   * }
+   * ```
    */
   async isInAllowlist(collectionAddress: string, address: string): Promise<boolean> {
     validateAddress(collectionAddress, 'collectionAddress');
@@ -811,7 +901,23 @@ export class CollectionModule extends BaseModule {
   }
 
   /**
-   * Check if collection is in allowlist-only mode
+   * Check if a collection is in allowlist-only minting mode
+   *
+   * @param collectionAddress - The collection contract address
+   *
+   * @returns Promise resolving to true if allowlist mode is enabled, false otherwise
+   *
+   * @throws {ZunoSDKError} INVALID_ADDRESS - If collection address is invalid
+   *
+   * @example
+   * ```typescript
+   * const isRestricted = await sdk.collection.isAllowlistOnly("0x1234...");
+   * if (isRestricted) {
+   *   console.log('Collection requires allowlist for minting');
+   * } else {
+   *   console.log('Collection is open for public minting');
+   * }
+   * ```
    */
   async isAllowlistOnly(collectionAddress: string): Promise<boolean> {
     validateAddress(collectionAddress, 'collectionAddress');

--- a/src/modules/ExchangeModule.ts
+++ b/src/modules/ExchangeModule.ts
@@ -148,8 +148,32 @@ export class ExchangeModule extends BaseModule {
   }
 
   /**
-   * Batch buy multiple NFTs from listings
-   * @param params.value - Total price in ETH (e.g., "3.0" for 3 NFTs at 1 ETH each)
+   * Batch buy multiple NFTs from active listings in a single transaction
+   *
+   * @param params - Batch purchase parameters
+   * @param params.listingIds - Array of listing IDs to purchase (bytes32 format)
+   * @param params.value - Total price in ETH covering all listings (e.g., "3.0")
+   * @param params.options - Transaction options (gas limit, gas price, etc.)
+   *
+   * @returns Promise resolving to transaction receipt
+   *
+   * @throws {Error} If listingIds array is empty
+   * @throws {ZunoSDKError} INVALID_LISTING_ID - If any listingId is not bytes32 format
+   * @throws {ZunoSDKError} TRANSACTION_FAILED - If transaction fails
+   * @throws {ZunoSDKError} INSUFFICIENT_FUNDS - If value doesn't cover total price
+   *
+   * @example
+   * ```typescript
+   * // Buy 3 NFTs at once
+   * const { tx } = await sdk.exchange.batchBuyNFT({
+   *   listingIds: [
+   *     '0x1234...', // Listing 1: 1.0 ETH
+   *     '0x5678...', // Listing 2: 1.5 ETH
+   *     '0x9abc...', // Listing 3: 0.5 ETH
+   *   ],
+   *   value: '3.0', // Total: 3.0 ETH
+   * });
+   * ```
    */
   async batchBuyNFT(params: BatchBuyNFTParams): Promise<{ tx: TransactionReceipt }> {
     const { listingIds, value, options } = params;
@@ -191,7 +215,25 @@ export class ExchangeModule extends BaseModule {
   }
 
   /**
-   * Cancel an NFT listing
+   * Cancel an active NFT listing and return the NFT to the seller
+   *
+   * @param listingId - The listing ID to cancel (bytes32 format)
+   * @param options - Transaction options (gas limit, gas price, etc.)
+   *
+   * @returns Promise resolving to transaction receipt
+   *
+   * @throws {ZunoSDKError} INVALID_LISTING_ID - If listingId is not valid bytes32 format
+   * @throws {ZunoSDKError} TRANSACTION_FAILED - If transaction fails
+   * @throws {ZunoSDKError} NOT_OWNER - If caller is not the listing owner
+   *
+   * @example
+   * ```typescript
+   * // Cancel a listing
+   * const { tx } = await sdk.exchange.cancelListing(
+   *   '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+   * );
+   * console.log('Listing cancelled:', tx.transactionHash);
+   * ```
    */
   async cancelListing(
     listingId: string,
@@ -223,7 +265,31 @@ export class ExchangeModule extends BaseModule {
   }
 
   /**
-   * Batch cancel multiple NFT listings
+   * Batch cancel multiple NFT listings in a single transaction
+   *
+   * @param params - Batch cancel parameters
+   * @param params.listingIds - Array of listing IDs to cancel (bytes32 format)
+   * @param params.options - Transaction options (gas limit, gas price, etc.)
+   *
+   * @returns Promise resolving to transaction receipt
+   *
+   * @throws {Error} If listingIds array is empty
+   * @throws {ZunoSDKError} INVALID_LISTING_ID - If any listingId is not bytes32 format
+   * @throws {ZunoSDKError} TRANSACTION_FAILED - If transaction fails
+   * @throws {ZunoSDKError} NOT_OWNER - If caller doesn't own any of the listings
+   *
+   * @example
+   * ```typescript
+   * // Cancel multiple listings at once
+   * const { tx } = await sdk.exchange.batchCancelListing({
+   *   listingIds: [
+   *     '0x1234...', // Listing 1
+   *     '0x5678...', // Listing 2
+   *     '0x9abc...', // Listing 3
+   *   ],
+   * });
+   * console.log('Cancelled all listings:', tx.transactionHash);
+   * ```
    */
   async batchCancelListing(
     params: BatchCancelListingParams
@@ -258,9 +324,35 @@ export class ExchangeModule extends BaseModule {
   }
 
   /**
-   * Get the total price buyer needs to pay (including royalty and taker fee)
-   * @param listingId - The listing ID
-   * @returns Total price in ETH (e.g., "1.05" for 1 ETH + 5% fees)
+   * Get the total price buyer needs to pay for a listing (including royalty and taker fee)
+   *
+   * This method calculates the final price including:
+   * - Base listing price
+   * - Creator royalty (if applicable)
+   * - Marketplace taker fee
+   *
+   * @param listingId - The listing ID to query (bytes32 format)
+   *
+   * @returns Total price in ETH as string (e.g., "1.05" for 1 ETH + 5% fees)
+   *
+   * @throws {ZunoSDKError} INVALID_LISTING_ID - If listingId is not valid bytes32 format
+   * @throws {ZunoSDKError} LISTING_NOT_FOUND - If listing doesn't exist
+   *
+   * @example
+   * ```typescript
+   * // Get total price for a listing
+   * const totalPrice = await sdk.exchange.getBuyerPrice(
+   *   '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+   * );
+   * console.log('Total price:', totalPrice, 'ETH');
+   * // Output: "Total price: 1.05 ETH" (1.0 base + 5% fees)
+   *
+   * // Use for buying
+   * await sdk.exchange.buyNFT({
+   *   listingId: '0x1234...',
+   *   value: totalPrice,
+   * });
+   * ```
    */
   async getBuyerPrice(listingId: string): Promise<string> {
     validateTokenId(listingId, 'listingId');


### PR DESCRIPTION
## Summary
Add comprehensive JSDoc documentation to all new public methods in v2.0.0 modules following CLAUDE.md guidelines.

## Methods Documented

### ExchangeModule
- batchBuyNFT()
- cancelListing()
- batchCancelListing()
- getBuyerPrice()

### AuctionModule
- batchCancelAuction()
- getPendingRefund()

### CollectionModule
- addToAllowlist()
- removeFromAllowlist()
- setAllowlistOnly()
- isInAllowlist()
- isAllowlistOnly()

## JSDoc Structure
Each method now includes:
- Description of purpose and behavior
- @param with types and descriptions
- @returns with return type info
- @throws with error codes and conditions
- @example with realistic usage code

Closes #26