### PR TITLE
refactor: replace hardcoded cache times with configurable constants u…

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@wagmi/core": "^2.13.0",
     "axios": "^1.7.0",
     "ethers": "^6.13.0",
+    "ms": "^2.1.3",
     "viem": "^2.21.0",
     "wagmi": "^2.12.0"
   },
@@ -102,6 +103,7 @@
     "@semantic-release/release-notes-generator": "^14.1.0",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.0",
+    "@types/ms": "^2.1.0",
     "@types/node": "^22.0.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       ethers:
         specifier: ^6.13.0
         version: 6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ms:
+        specifier: ^2.1.3
+        version: 2.1.3
       viem:
         specifier: ^2.21.0
         version: 2.39.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -60,6 +63,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/ms':
+        specifier: ^2.1.0
+        version: 2.1.0
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1

--- a/src/core/ZunoAPIClient.ts
+++ b/src/core/ZunoAPIClient.ts
@@ -14,6 +14,7 @@ import type {
   GetContractInfoResponse,
   GetNetworksResponse,
 } from '../types/api';
+import { DEFAULT_CACHE_TIMES, type CacheConfig } from '../types/config';
 import { ZunoSDKError, ErrorCodes } from '../utils/errors';
 
 /**
@@ -339,17 +340,23 @@ export class ZunoAPIClient {
 
 /**
  * Create query options for fetching ABI
+ *
+ * @param client - ZunoAPIClient instance
+ * @param contractName - Contract name
+ * @param network - Network identifier
+ * @param cacheConfig - Optional cache configuration to override defaults
  */
 export function createABIQueryOptions(
   client: ZunoAPIClient,
   contractName: string,
-  network: string
+  network: string,
+  cacheConfig?: CacheConfig
 ) {
   return {
     queryKey: abiQueryKeys.detail(contractName, network),
     queryFn: () => client.getABI(contractName, network),
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes (formerly cacheTime)
+    staleTime: cacheConfig?.ttl ?? DEFAULT_CACHE_TIMES.STALE_TIME,
+    gcTime: cacheConfig?.gcTime ?? DEFAULT_CACHE_TIMES.GC_TIME,
     retry: 3,
     retryDelay: (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 30000),
   };
@@ -357,16 +364,21 @@ export function createABIQueryOptions(
 
 /**
  * Create query options for fetching ABI by ID
+ *
+ * @param client - ZunoAPIClient instance
+ * @param abiId - ABI identifier
+ * @param cacheConfig - Optional cache configuration to override defaults
  */
 export function createABIByIdQueryOptions(
   client: ZunoAPIClient,
-  abiId: string
+  abiId: string,
+  cacheConfig?: CacheConfig
 ) {
   return {
     queryKey: abiQueryKeys.byId(abiId),
     queryFn: () => client.getABIById(abiId),
-    staleTime: 5 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
+    staleTime: cacheConfig?.ttl ?? DEFAULT_CACHE_TIMES.STALE_TIME,
+    gcTime: cacheConfig?.gcTime ?? DEFAULT_CACHE_TIMES.GC_TIME,
     retry: 3,
     retryDelay: (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 30000),
   };
@@ -374,17 +386,23 @@ export function createABIByIdQueryOptions(
 
 /**
  * Create query options for fetching contract info
+ *
+ * @param client - ZunoAPIClient instance
+ * @param address - Contract address
+ * @param network - Network identifier
+ * @param cacheConfig - Optional cache configuration to override defaults
  */
 export function createContractInfoQueryOptions(
   client: ZunoAPIClient,
   address: string,
-  network: string
+  network: string,
+  cacheConfig?: CacheConfig
 ) {
   return {
     queryKey: abiQueryKeys.contracts(address, network),
     queryFn: () => client.getContractInfo(address, network),
-    staleTime: 5 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
+    staleTime: cacheConfig?.ttl ?? DEFAULT_CACHE_TIMES.STALE_TIME,
+    gcTime: cacheConfig?.gcTime ?? DEFAULT_CACHE_TIMES.GC_TIME,
     retry: 3,
     retryDelay: (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 30000),
   };
@@ -392,13 +410,20 @@ export function createContractInfoQueryOptions(
 
 /**
  * Create query options for fetching networks
+ * Uses extended cache times since network data rarely changes
+ *
+ * @param client - ZunoAPIClient instance
+ * @param cacheConfig - Optional cache configuration to override defaults
  */
-export function createNetworksQueryOptions(client: ZunoAPIClient) {
+export function createNetworksQueryOptions(
+  client: ZunoAPIClient,
+  cacheConfig?: CacheConfig
+) {
   return {
     queryKey: abiQueryKeys.networks(),
     queryFn: () => client.getNetworks(),
-    staleTime: 30 * 60 * 1000, // 30 minutes
-    gcTime: 60 * 60 * 1000, // 1 hour
+    staleTime: cacheConfig?.ttl ?? DEFAULT_CACHE_TIMES.STALE_TIME_EXTENDED,
+    gcTime: cacheConfig?.gcTime ?? DEFAULT_CACHE_TIMES.GC_TIME_EXTENDED,
     retry: 3,
     retryDelay: (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 30000),
   };

--- a/src/core/ZunoSDK.ts
+++ b/src/core/ZunoSDK.ts
@@ -13,7 +13,7 @@ import { EventEmitter } from "../utils/events";
 import { ZunoSDKError, ErrorCodes } from "../utils/errors";
 import { ZunoLogger, createNoOpLogger, type Logger } from "../utils/logger";
 import { logStore } from "../utils/logStore";
-import type { ZunoSDKConfig, SDKOptions } from "../types/config";
+import { DEFAULT_CACHE_TIMES, type ZunoSDKConfig, type SDKOptions } from "../types/config";
 
 // Singleton instance (module-level private variable)
 let _singletonInstance: ZunoSDK | null = null;
@@ -386,8 +386,8 @@ export class ZunoSDK extends EventEmitter {
     return new QueryClient({
       defaultOptions: {
         queries: {
-          staleTime: cacheConfig.ttl || 5 * 60 * 1000, // 5 minutes
-          gcTime: cacheConfig.gcTime || 10 * 60 * 1000, // 10 minutes
+          staleTime: cacheConfig.ttl ?? DEFAULT_CACHE_TIMES.STALE_TIME,
+          gcTime: cacheConfig.gcTime ?? DEFAULT_CACHE_TIMES.GC_TIME,
           retry: this.config.retryPolicy?.maxRetries || 3,
           retryDelay: (attemptIndex) => {
             const delay = this.config.retryPolicy?.initialDelay || 1000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ export { CollectionModule } from './modules/CollectionModule';
 export { AuctionModule } from './modules/AuctionModule';
 export { BaseModule } from './modules/BaseModule';
 
-// Types
+// Types & Constants
+export { DEFAULT_CACHE_TIMES } from './types/config';
 export type * from './types/config';
 export type * from './types/entities';
 export type * from './types/api';

--- a/src/react/provider/ZunoProvider.tsx
+++ b/src/react/provider/ZunoProvider.tsx
@@ -18,7 +18,7 @@ import { injected, walletConnect, coinbaseWallet } from "wagmi/connectors";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserProvider } from "ethers";
 import { ZunoContextProvider, useZuno } from "./ZunoContextProvider";
-import type { ZunoSDKConfig } from "../../types/config";
+import { DEFAULT_CACHE_TIMES, type ZunoSDKConfig } from "../../types/config";
 
 export interface ZunoProviderProps {
   config: ZunoSDKConfig;
@@ -69,8 +69,8 @@ export function ZunoProvider({ config, children }: ZunoProviderProps) {
       new QueryClient({
         defaultOptions: {
           queries: {
-            staleTime: config.cache?.ttl || 5 * 60 * 1000,
-            gcTime: config.cache?.gcTime || 10 * 60 * 1000,
+            staleTime: config.cache?.ttl ?? DEFAULT_CACHE_TIMES.STALE_TIME,
+            gcTime: config.cache?.gcTime ?? DEFAULT_CACHE_TIMES.GC_TIME,
             retry: config.retryPolicy?.maxRetries || 3,
             retryDelay: (attemptIndex) => {
               const delay = config.retryPolicy?.initialDelay || 1000;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,9 +2,25 @@
  * SDK Configuration Types
  */
 
+import ms from 'ms';
 import type { QueryClient } from '@tanstack/react-query';
 import type { ethers } from 'ethers';
 import type { LoggerConfig } from '../utils/logger';
+
+/**
+ * Default cache time constants (in milliseconds)
+ * These can be overridden via CacheConfig
+ */
+export const DEFAULT_CACHE_TIMES = {
+  /** Default stale time for queries (5 minutes) */
+  STALE_TIME: ms('5m'),
+  /** Default garbage collection time (10 minutes) */
+  GC_TIME: ms('10m'),
+  /** Extended stale time for rarely changing data like networks (30 minutes) */
+  STALE_TIME_EXTENDED: ms('30m'),
+  /** Extended garbage collection time (1 hour) */
+  GC_TIME_EXTENDED: ms('1h'),
+} as const;
 
 /**
  * Supported blockchain networks

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@
  * Type definitions for Zuno Marketplace SDK
  */
 
+export { DEFAULT_CACHE_TIMES } from './config';
 export type * from './config';
 export type * from './entities';
 export type * from './api';


### PR DESCRIPTION

- Add DEFAULT_CACHE_TIMES constant with STALE_TIME, GC_TIME, STALE_TIME_EXTENDED, GC_TIME_EXTENDED
- Use ms library for human-readable time values (e.g., '5m', '10m', '30m', '1h')
- Update query option factories to accept optional CacheConfig parameter
- Refactor ZunoSDK, ZunoProvider, and ZunoAPIClient to use constants
- Export DEFAULT_CACHE_TIMES from main SDK entry point

Closes #47