### PR TITLE
test: add coverage for chains/connectors/browser/helpers/ZunoContextProvider

### DIFF
--- a/src/__tests__/react/ZunoContextProvider.test.tsx
+++ b/src/__tests__/react/ZunoContextProvider.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Tests for ZunoContextProvider and the useZunoSDK / useZunoLogger hooks.
+ *
+ * `ZunoContextProvider` deliberately does NOT depend on Wagmi / viem, so we
+ * can exercise it without the ESM mocks needed elsewhere in the React tree.
+ */
+
+import React, { type ReactNode } from 'react';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  ZunoContextProvider,
+  useZuno,
+} from '../../react/provider/ZunoContextProvider';
+import { useZunoSDK } from '../../react/hooks/useZunoSDK';
+import { useZunoLogger } from '../../react/hooks/useZunoLogger';
+import { ZunoSDK } from '../../core/ZunoSDK';
+import { ZunoSDKError, ErrorCodes } from '../../utils/errors';
+
+function buildWrapper(sdk?: ZunoSDK, queryClient?: QueryClient) {
+  const client = queryClient ?? new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <ZunoContextProvider sdk={sdk} config={sdk ? undefined : { apiKey: 'test', network: 'sepolia' }}>
+        {children}
+      </ZunoContextProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('ZunoContextProvider', () => {
+  it('exposes a pre-initialized SDK through useZunoSDK', () => {
+    const externalSdk = new ZunoSDK({ apiKey: 'external', network: 'mainnet' });
+    const wrapper = buildWrapper(externalSdk);
+
+    const { result } = renderHook(() => useZunoSDK(), { wrapper });
+    expect(result.current).toBe(externalSdk);
+    expect(result.current.getConfig().apiKey).toBe('external');
+    expect(result.current.getConfig().network).toBe('mainnet');
+  });
+
+  it('creates an SDK from config when no external instance is provided', () => {
+    const wrapper = buildWrapper();
+    const { result } = renderHook(() => useZunoSDK(), { wrapper });
+    expect(result.current).toBeInstanceOf(ZunoSDK);
+    expect(result.current.getConfig().apiKey).toBe('test');
+  });
+
+  it('throws when neither config nor sdk is provided', () => {
+    const client = new QueryClient();
+    expect(() =>
+      renderHook(() => useZunoSDK(), {
+        wrapper: ({ children }) => {
+          const ProviderAny = ZunoContextProvider as unknown as React.ComponentType<{ children: ReactNode }>;
+          return (
+            <QueryClientProvider client={client}>
+              <ProviderAny>{children}</ProviderAny>
+            </QueryClientProvider>
+          );
+        },
+      }),
+    ).toThrow(/requires either config or sdk/);
+  });
+
+  it('returns the same SDK across multiple useZunoSDK calls inside one provider', () => {
+    const externalSdk = new ZunoSDK({ apiKey: 'shared', network: 'sepolia' });
+    const wrapper = buildWrapper(externalSdk);
+
+    const { result: r1 } = renderHook(() => useZunoSDK(), { wrapper });
+    const { result: r2 } = renderHook(() => useZunoSDK(), { wrapper });
+    expect(r1.current).toBe(externalSdk);
+    expect(r2.current).toBe(externalSdk);
+  });
+});
+
+describe('useZunoSDK guard', () => {
+  it('throws ZunoSDKError with MISSING_PROVIDER when used without a provider', () => {
+    expect.assertions(2);
+    try {
+      renderHook(() => useZunoSDK());
+    } catch (err) {
+      expect(err).toBeInstanceOf(ZunoSDKError);
+      expect((err as ZunoSDKError).code).toBe(ErrorCodes.MISSING_PROVIDER);
+    }
+  });
+});
+
+describe('useZunoLogger', () => {
+  it('returns the SDK logger with the standard log level methods', () => {
+    const sdk = new ZunoSDK({ apiKey: 'log', network: 'sepolia' });
+    const wrapper = buildWrapper(sdk);
+
+    const { result, rerender } = renderHook(() => useZunoLogger(), { wrapper });
+    expect(result.current).toBe(sdk.logger);
+    expect(typeof result.current.debug).toBe('function');
+    expect(typeof result.current.info).toBe('function');
+    expect(typeof result.current.warn).toBe('function');
+    expect(typeof result.current.error).toBe('function');
+
+    rerender();
+    expect(result.current).toBe(sdk.logger);
+  });
+
+  it('propagates the MISSING_PROVIDER error when called outside a provider', () => {
+    expect(() => renderHook(() => useZunoLogger())).toThrow(ZunoSDKError);
+  });
+});
+
+describe('useZuno (SSR-aware helper)', () => {
+  it('returns the context SDK when available', () => {
+    const sdk = new ZunoSDK({ apiKey: 'ssr', network: 'sepolia' });
+    const wrapper = buildWrapper(sdk);
+    const { result } = renderHook(() => useZuno(), { wrapper });
+    expect(result.current).toBe(sdk);
+  });
+
+  it('throws in the browser when used without a provider', () => {
+    expect(() => renderHook(() => useZuno())).toThrow(/must be used within ZunoContextProvider/);
+  });
+});

--- a/src/__tests__/react/utils/browser.node.test.ts
+++ b/src/__tests__/react/utils/browser.node.test.ts
@@ -1,0 +1,15 @@
+/**
+ * @jest-environment node
+ *
+ * SSR-side coverage for `isBrowser`. Running in the node environment makes
+ * `typeof window === 'undefined'` naturally true.
+ */
+
+import { isBrowser } from '../../../react/utils/browser';
+
+describe('isBrowser (node / SSR)', () => {
+  it('returns false when window is undefined', () => {
+    expect(typeof window).toBe('undefined');
+    expect(isBrowser()).toBe(false);
+  });
+});

--- a/src/__tests__/react/utils/browser.test.ts
+++ b/src/__tests__/react/utils/browser.test.ts
@@ -1,0 +1,14 @@
+/**
+ * Tests for browser environment detection helpers (browser path).
+ * The SSR path lives in a sibling file with `@jest-environment node` so
+ * `typeof window === 'undefined'` is naturally true there.
+ */
+
+import { isBrowser } from '../../../react/utils/browser';
+
+describe('isBrowser (jsdom)', () => {
+  it('returns true when window is defined', () => {
+    expect(typeof window).toBe('object');
+    expect(isBrowser()).toBe(true);
+  });
+});

--- a/src/__tests__/react/utils/chains.test.ts
+++ b/src/__tests__/react/utils/chains.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for chain utilities (wagmi chain configuration)
+ *
+ * `wagmi/chains` ships only as ESM and re-exports from `viem/chains`, so we
+ * mock it with simple chain-like sentinels and assert on identity / shape.
+ */
+
+jest.mock('wagmi/chains', () => ({
+  mainnet: { id: 1, name: 'Ethereum' },
+  sepolia: { id: 11155111, name: 'Sepolia' },
+  polygon: { id: 137, name: 'Polygon' },
+  arbitrum: { id: 42161, name: 'Arbitrum One' },
+}));
+
+import { mainnet, sepolia, polygon, arbitrum } from 'wagmi/chains';
+import {
+  getChainFromNetwork,
+  getChainsFromNetworks,
+} from '../../../react/utils/chains';
+
+describe('getChainFromNetwork', () => {
+  describe('named networks', () => {
+    it('returns mainnet for "mainnet"', () => {
+      expect(getChainFromNetwork('mainnet')).toBe(mainnet);
+    });
+
+    it('returns sepolia for "sepolia"', () => {
+      expect(getChainFromNetwork('sepolia')).toBe(sepolia);
+    });
+
+    it('returns polygon for "polygon"', () => {
+      expect(getChainFromNetwork('polygon')).toBe(polygon);
+    });
+
+    it('returns arbitrum for "arbitrum"', () => {
+      expect(getChainFromNetwork('arbitrum')).toBe(arbitrum);
+    });
+  });
+
+  describe('numeric chain IDs', () => {
+    it('builds a custom chain with sensible defaults for unknown ID', () => {
+      const chain = getChainFromNetwork(31337);
+      expect(chain.id).toBe(31337);
+      expect(chain.name).toBe('Anvil');
+      expect(chain.testnet).toBe(true);
+      expect(chain.nativeCurrency).toEqual({
+        name: 'Ether',
+        symbol: 'ETH',
+        decimals: 18,
+      });
+      expect(chain.rpcUrls.default.http).toEqual(['http://127.0.0.1:8545']);
+      expect(chain.blockExplorers).toBeUndefined();
+    });
+
+    it('honors custom name, rpcUrl and testnet flag', () => {
+      const chain = getChainFromNetwork(1337, {
+        name: 'My Local',
+        rpcUrl: 'http://localhost:9999',
+        testnet: false,
+      });
+      expect(chain.id).toBe(1337);
+      expect(chain.name).toBe('My Local');
+      expect(chain.testnet).toBe(false);
+      expect(chain.rpcUrls.default.http).toEqual(['http://localhost:9999']);
+    });
+
+    it('exposes block explorer config when provided', () => {
+      const chain = getChainFromNetwork(31337, {
+        blockExplorer: { name: 'Local Explorer', url: 'http://localhost:4000' },
+      });
+      expect(chain.blockExplorers?.default).toEqual({
+        name: 'Local Explorer',
+        url: 'http://localhost:4000',
+      });
+    });
+  });
+
+  describe('fallback behaviour', () => {
+    it('falls back to sepolia for an unknown network identifier', () => {
+      // @ts-expect-error - intentionally pass an unsupported value to exercise fallback
+      const chain = getChainFromNetwork('unknown-network');
+      expect(chain).toBe(sepolia);
+    });
+  });
+});
+
+describe('getChainsFromNetworks', () => {
+  it('maps an array of named networks to wagmi chains', () => {
+    const chains = getChainsFromNetworks(['mainnet', 'sepolia']);
+    expect(chains).toEqual([mainnet, sepolia]);
+  });
+
+  it('applies per-chain custom config to numeric IDs only', () => {
+    const chains = getChainsFromNetworks(
+      [31337, 'sepolia', 1337],
+      {
+        31337: { name: 'Anvil-1', rpcUrl: 'http://localhost:8545' },
+        1337: { name: 'Anvil-2', rpcUrl: 'http://localhost:8546' },
+      },
+    );
+
+    expect(chains).toHaveLength(3);
+    expect(chains[0].id).toBe(31337);
+    expect(chains[0].name).toBe('Anvil-1');
+    expect(chains[0].rpcUrls.default.http).toEqual(['http://localhost:8545']);
+
+    expect(chains[1]).toBe(sepolia);
+
+    expect(chains[2].id).toBe(1337);
+    expect(chains[2].name).toBe('Anvil-2');
+    expect(chains[2].rpcUrls.default.http).toEqual(['http://localhost:8546']);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(getChainsFromNetworks([])).toEqual([]);
+  });
+});

--- a/src/__tests__/react/utils/connectors.test.ts
+++ b/src/__tests__/react/utils/connectors.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for wagmi connector helpers
+ *
+ * The underlying wagmi/connectors entry pulls heavy ESM dependencies that are
+ * costly to load in jsdom, so we mock the connector factories and assert on
+ * the call arguments + which factories the helper invokes.
+ */
+
+jest.mock('wagmi/connectors', () => ({
+  injected: jest.fn(() => ({ type: 'injected' })),
+  walletConnect: jest.fn((opts: unknown) => ({ type: 'walletConnect', opts })),
+  coinbaseWallet: jest.fn((opts: unknown) => ({ type: 'coinbaseWallet', opts })),
+}));
+
+jest.mock('../../../react/utils/browser', () => ({
+  isBrowser: jest.fn(() => true),
+}));
+
+import { injected, walletConnect, coinbaseWallet } from 'wagmi/connectors';
+import { isBrowser } from '../../../react/utils/browser';
+import {
+  createDefaultConnectors,
+  createSSRSafeConnectors,
+} from '../../../react/utils/connectors';
+
+const injectedMock = injected as jest.MockedFunction<typeof injected>;
+const walletConnectMock = walletConnect as jest.MockedFunction<typeof walletConnect>;
+const coinbaseMock = coinbaseWallet as jest.MockedFunction<typeof coinbaseWallet>;
+const isBrowserMock = isBrowser as jest.MockedFunction<typeof isBrowser>;
+
+beforeEach(() => {
+  injectedMock.mockClear();
+  walletConnectMock.mockClear();
+  coinbaseMock.mockClear();
+  isBrowserMock.mockReset();
+  isBrowserMock.mockReturnValue(true);
+});
+
+describe('createDefaultConnectors', () => {
+  it('includes injected and coinbase by default and skips walletConnect without a projectId', () => {
+    const connectors = createDefaultConnectors();
+    expect(connectors).toHaveLength(2);
+    expect(injectedMock).toHaveBeenCalledTimes(1);
+    expect(coinbaseMock).toHaveBeenCalledWith({ appName: 'Zuno Marketplace' });
+    expect(walletConnectMock).not.toHaveBeenCalled();
+  });
+
+  it('uses a custom appName for coinbaseWallet', () => {
+    createDefaultConnectors({ appName: 'My App' });
+    expect(coinbaseMock).toHaveBeenCalledWith({ appName: 'My App' });
+  });
+
+  it('adds walletConnect when projectId is provided', () => {
+    const connectors = createDefaultConnectors({
+      walletConnectProjectId: 'wc-test',
+    });
+    expect(connectors).toHaveLength(3);
+    expect(walletConnectMock).toHaveBeenCalledWith({
+      projectId: 'wc-test',
+      showQrModal: true,
+    });
+  });
+
+  it('respects explicit includeWalletConnect=false even with a projectId', () => {
+    const connectors = createDefaultConnectors({
+      walletConnectProjectId: 'wc-test',
+      includeWalletConnect: false,
+    });
+    expect(connectors).toHaveLength(2);
+    expect(walletConnectMock).not.toHaveBeenCalled();
+  });
+
+  it('omits injected and coinbase when explicitly disabled', () => {
+    const connectors = createDefaultConnectors({
+      includeInjected: false,
+      includeCoinbaseWallet: false,
+    });
+    expect(connectors).toHaveLength(0);
+    expect(injectedMock).not.toHaveBeenCalled();
+    expect(coinbaseMock).not.toHaveBeenCalled();
+  });
+
+  it('skips walletConnect when includeWalletConnect=true but projectId is missing', () => {
+    const connectors = createDefaultConnectors({
+      includeInjected: false,
+      includeCoinbaseWallet: false,
+      includeWalletConnect: true,
+    });
+    expect(connectors).toHaveLength(0);
+    expect(walletConnectMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('createSSRSafeConnectors', () => {
+  it('returns connectors in a browser environment', () => {
+    isBrowserMock.mockReturnValue(true);
+    const connectors = createSSRSafeConnectors({
+      walletConnectProjectId: 'wc-test',
+    });
+    expect(connectors).toHaveLength(3);
+  });
+
+  it('returns an empty array on the server', () => {
+    isBrowserMock.mockReturnValue(false);
+    const connectors = createSSRSafeConnectors({
+      walletConnectProjectId: 'wc-test',
+    });
+    expect(connectors).toEqual([]);
+    expect(injectedMock).not.toHaveBeenCalled();
+    expect(coinbaseMock).not.toHaveBeenCalled();
+    expect(walletConnectMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/utils/helpers-extras.test.ts
+++ b/src/__tests__/utils/helpers-extras.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Additional coverage for src/utils/helpers.ts
+ *
+ * The original helpers.test.ts focuses on `validateBytes32`. This suite covers
+ * the remaining pure helpers: retries, transaction overrides, value parsing,
+ * scheduling helpers, and the safeCall wrapper.
+ */
+
+import { ethers } from 'ethers';
+import {
+  withRetry,
+  buildTransactionOverrides,
+  validateAndFormatAddress,
+  toWei,
+  fromWei,
+  debounce,
+  throttle,
+  safeCall,
+  formatTransactionReceipt,
+  parseTransactionError,
+} from '../../utils/helpers';
+import { ZunoSDKError, ErrorCodes } from '../../utils/errors';
+
+describe('withRetry', () => {
+  it('returns the value on the first successful attempt without retrying', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    await expect(withRetry(fn)).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries transient failures and eventually succeeds', async () => {
+    const fn = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValueOnce(new Error('network glitch'))
+      .mockRejectedValueOnce(new Error('network glitch'))
+      .mockResolvedValueOnce('eventually');
+
+    const result = await withRetry(fn, { initialDelay: 1, maxDelay: 2, maxRetries: 3 });
+    expect(result).toBe('eventually');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops immediately on non-retryable errors and rethrows the original error', async () => {
+    const error = new Error('insufficient funds for transfer');
+    const fn = jest.fn<Promise<string>, []>().mockRejectedValue(error);
+
+    await expect(withRetry(fn, { initialDelay: 1, maxRetries: 3 })).rejects.toBe(error);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors a custom shouldRetry predicate', async () => {
+    const error = new Error('please retry');
+    const fn = jest.fn<Promise<string>, []>().mockRejectedValue(error);
+    const shouldRetry = jest.fn().mockReturnValue(false);
+
+    await expect(
+      withRetry(fn, { initialDelay: 1, maxRetries: 2 }, shouldRetry),
+    ).rejects.toBe(error);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(shouldRetry).toHaveBeenCalledWith(error, 0);
+  });
+
+  it('exhausts maxRetries and throws the last error', async () => {
+    const error = new Error('flaky rpc');
+    const fn = jest.fn<Promise<string>, []>().mockRejectedValue(error);
+
+    await expect(
+      withRetry(fn, { initialDelay: 1, maxDelay: 2, maxRetries: 2 }),
+    ).rejects.toBe(error);
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('supports linear backoff without throwing', async () => {
+    const fn = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValueOnce(new Error('temp'))
+      .mockResolvedValueOnce('done');
+    const result = await withRetry(fn, {
+      initialDelay: 1,
+      maxDelay: 1,
+      maxRetries: 1,
+      backoff: 'linear',
+    });
+    expect(result).toBe('done');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('buildTransactionOverrides', () => {
+  it('returns an empty object when no options are provided', () => {
+    expect(buildTransactionOverrides()).toEqual({});
+    expect(buildTransactionOverrides({})).toEqual({});
+  });
+
+  it('converts string value to BigInt', () => {
+    const overrides = buildTransactionOverrides({ value: '1000000000000000000' });
+    expect(overrides.value).toBe(1000000000000000000n);
+  });
+
+  it('passes through bigint value unchanged', () => {
+    const overrides = buildTransactionOverrides({ value: 42n });
+    expect(overrides.value).toBe(42n);
+  });
+
+  it('copies gasLimit/gasPrice/EIP-1559 fees and nonce when provided', () => {
+    const overrides = buildTransactionOverrides({
+      gasLimit: '21000',
+      gasPrice: '1000000000',
+      maxFeePerGas: '2000000000',
+      maxPriorityFeePerGas: '1500000000',
+      nonce: 7,
+    });
+    expect(overrides).toEqual({
+      gasLimit: '21000',
+      gasPrice: '1000000000',
+      maxFeePerGas: '2000000000',
+      maxPriorityFeePerGas: '1500000000',
+      nonce: 7,
+    });
+  });
+
+  it('treats nonce=0 as a valid override', () => {
+    const overrides = buildTransactionOverrides({ nonce: 0 });
+    expect(overrides.nonce).toBe(0);
+  });
+});
+
+describe('validateAndFormatAddress', () => {
+  it('returns the checksummed address for a valid lowercase address', () => {
+    const formatted = validateAndFormatAddress(
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
+    expect(formatted).toBe('0x52908400098527886E0F7030069857D2E4169EE7');
+  });
+
+  it('throws ZunoSDKError when given a non-string value', () => {
+    // @ts-expect-error - exercising the runtime guard
+    expect(() => validateAndFormatAddress(undefined)).toThrow(ZunoSDKError);
+    // @ts-expect-error
+    expect(() => validateAndFormatAddress(123)).toThrow(/Address must be a string/);
+  });
+
+  it('throws ZunoSDKError for malformed addresses', () => {
+    expect(() => validateAndFormatAddress('not-an-address')).toThrow(/Invalid Ethereum address/);
+  });
+});
+
+describe('toWei / fromWei', () => {
+  it('round-trips a whole ether amount', () => {
+    const wei = toWei('1');
+    expect(wei).toBe(10n ** 18n);
+    expect(fromWei(wei)).toBe('1.0');
+  });
+
+  it('accepts numeric inputs', () => {
+    expect(toWei(0.5)).toBe(5n * 10n ** 17n);
+  });
+
+  it('throws ZunoSDKError with INVALID_AMOUNT for unparseable input', () => {
+    expect.assertions(2);
+    try {
+      toWei('not-a-number');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ZunoSDKError);
+      expect((err as ZunoSDKError).code).toBe(ErrorCodes.INVALID_AMOUNT);
+    }
+  });
+
+  it('fromWei throws ZunoSDKError for invalid wei values', () => {
+    expect(() => fromWei('not-wei')).toThrow(ZunoSDKError);
+  });
+});
+
+describe('debounce', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('only invokes the function once for back-to-back calls within the wait window', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100);
+    debounced('a');
+    debounced('b');
+    debounced('c');
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('c');
+  });
+
+  it('invokes the function again after the wait window elapses', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 50);
+    debounced('first');
+    jest.advanceTimersByTime(50);
+    debounced('second');
+    jest.advanceTimersByTime(50);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(1, 'first');
+    expect(fn).toHaveBeenNthCalledWith(2, 'second');
+  });
+});
+
+describe('throttle', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('invokes the function on the leading edge and suppresses subsequent calls', () => {
+    const fn = jest.fn();
+    const throttled = throttle(fn, 100);
+    throttled('a');
+    throttled('b');
+    throttled('c');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('a');
+    jest.advanceTimersByTime(100);
+    throttled('d');
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('d');
+  });
+});
+
+describe('safeCall', () => {
+  it('returns the resolved value when the function succeeds', async () => {
+    const result = await safeCall(async () => 'ok', 'fallback');
+    expect(result).toBe('ok');
+  });
+
+  it('returns the fallback when the function throws', async () => {
+    const result = await safeCall(async () => {
+      throw new Error('boom');
+    }, 'fallback');
+    expect(result).toBe('fallback');
+  });
+});
+
+describe('formatTransactionReceipt', () => {
+  it('maps ethers receipt fields into the SDK shape', () => {
+    const ethersReceipt = {
+      hash: '0xhash',
+      blockNumber: 12345,
+      blockHash: '0xblock',
+      gasUsed: 21000n,
+      cumulativeGasUsed: 42000n,
+      status: 1,
+      logs: [{ a: 1 }, { b: 2 }],
+    } as unknown as ethers.TransactionReceipt;
+
+    const receipt = formatTransactionReceipt(ethersReceipt);
+
+    expect(receipt.hash).toBe('0xhash');
+    expect(receipt.blockNumber).toBe(12345);
+    expect(receipt.blockHash).toBe('0xblock');
+    expect(receipt.gasUsed).toBe('21000');
+    expect(receipt.cumulativeGasUsed).toBe('42000');
+    expect(receipt.status).toBe('success');
+    expect(receipt.logs).toHaveLength(2);
+    expect(typeof receipt.timestamp).toBe('number');
+  });
+
+  it('marks status as failed when status != 1 and tolerates missing optional fields', () => {
+    const ethersReceipt = {
+      hash: '0xhash',
+      blockNumber: undefined,
+      blockHash: undefined,
+      gasUsed: undefined,
+      cumulativeGasUsed: undefined,
+      status: 0,
+      logs: undefined,
+    } as unknown as ethers.TransactionReceipt;
+
+    const receipt = formatTransactionReceipt(ethersReceipt);
+    expect(receipt.status).toBe('failed');
+    expect(receipt.blockNumber).toBe(0);
+    expect(receipt.blockHash).toBe('');
+    expect(receipt.gasUsed).toBe('0');
+    expect(receipt.cumulativeGasUsed).toBe('0');
+    expect(receipt.logs).toEqual([]);
+  });
+});
+
+describe('parseTransactionError', () => {
+  const cases: Array<[string, string]> = [
+    ['user rejected the request', ErrorCodes.USER_REJECTED],
+    ['insufficient funds for gas', ErrorCodes.INSUFFICIENT_FUNDS],
+    ['nonce too low for the account', ErrorCodes.NONCE_TOO_LOW],
+    ['nonce too high', ErrorCodes.NONCE_TOO_LOW],
+    ['execution reverted: bad state', ErrorCodes.TRANSACTION_REVERTED],
+    ['intrinsic gas too low', ErrorCodes.GAS_ESTIMATION_FAILED],
+  ];
+
+  it.each(cases)('maps "%s" to the expected error code', (message, expectedCode) => {
+    const err = parseTransactionError(new Error(message));
+    expect(err).toBeInstanceOf(ZunoSDKError);
+    expect(err.code).toBe(expectedCode);
+  });
+
+  it('falls back to TRANSACTION_FAILED for unrecognised messages', () => {
+    const err = parseTransactionError(new Error('something else'));
+    expect(err.code).toBe(ErrorCodes.TRANSACTION_FAILED);
+  });
+});

--- a/tests/setup/jest.setup.js
+++ b/tests/setup/jest.setup.js
@@ -20,17 +20,19 @@ global.fetch = jest.fn().mockResolvedValue({
   text: jest.fn().mockResolvedValue(''),
 });
 
-// Mock window.matchMedia
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: jest.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-});
+// Mock window.matchMedia (jsdom only — skipped under the node test environment).
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+}


### PR DESCRIPTION
## Summary

Adds ~62 new tests to bring previously low-coverage modules up:

| Area | Before | After |
|---|---|---|
| `src/react/utils/chains.ts` | 0% | **100%** |
| `src/react/utils/connectors.ts` | 0% | **100%** |
| `src/react/utils/browser.ts` | 50% | **100%** |
| `src/utils/helpers.ts` | 44% | **97.9%** |
| `src/react/provider/ZunoContextProvider.tsx` + `useZunoSDK`/`useZunoLogger`/`useZuno` | 17–50% | ~100% |

Tests added under `src/__tests__/react/utils/`, `src/__tests__/react/ZunoContextProvider.test.tsx`, and `src/__tests__/utils/helpers-extras.test.ts`. The new `ZunoContextProvider` suite is wagmi-free, so it doesn't hit the ESM issue blocking the existing `useZunoSDK.test.tsx` (left skipped on purpose).

Also a tiny infra tweak in `tests/setup/jest.setup.js`: guard the `window.matchMedia` mock behind `typeof window !== 'undefined'` so per-file `@jest-environment node` specs (used by the new SSR `isBrowser` test) no longer crash on startup.

## Test plan

```bash
pnpm install
pnpm test           # 567 -> 629 passing tests (+62)
pnpm lint
pnpm type-check
```

No production source changes — only test files + a setup guard.

---
Requested by: Trần Quang Đãng (tranquangdang21@gmail.com)
Devin session: https://app.devin.ai/sessions/79196eb702e540bcb7f25327328ad45d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added comprehensive test coverage for context provider hooks, utilities, and helper functions
* Implemented SSR compatibility tests ensuring proper browser detection across environments
* Enhanced chain and connector utility test coverage
* Improved Jest configuration for non-browser environment compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunokit/zuno-marketplace-sdk/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->