### PR TITLE
feat(react): add useClipboard hook

### DIFF
--- a/src/__tests__/react/useClipboard.test.tsx
+++ b/src/__tests__/react/useClipboard.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * useClipboard Hook Tests
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useClipboard } from '../../react/hooks/useClipboard';
+
+describe('useClipboard', () => {
+  let originalClipboard: PropertyDescriptor | undefined;
+  let writeTextMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    writeTextMock = jest.fn().mockResolvedValue(undefined);
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: writeTextMock },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard);
+    } else {
+      delete (navigator as Navigator & { clipboard?: unknown }).clipboard;
+    }
+  });
+
+  it('returns default state before any copy', () => {
+    const { result } = renderHook(() => useClipboard());
+    expect(result.current.value).toBeNull();
+    expect(result.current.copied).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('copies a value and exposes the copied flag', async () => {
+    const onCopy = jest.fn();
+    const { result } = renderHook(() => useClipboard({ onCopy }));
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.copy('0xdeadbeef');
+    });
+
+    expect(ok).toBe(true);
+    expect(writeTextMock).toHaveBeenCalledWith('0xdeadbeef');
+    expect(result.current.value).toBe('0xdeadbeef');
+    expect(result.current.copied).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(onCopy).toHaveBeenCalledWith('0xdeadbeef');
+  });
+
+  it('resets the copied flag after resetAfterMs', async () => {
+    const { result } = renderHook(() => useClipboard({ resetAfterMs: 500 }));
+
+    await act(async () => {
+      await result.current.copy('hello');
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => expect(result.current.copied).toBe(false));
+    expect(result.current.value).toBe('hello');
+  });
+
+  it('does not auto-reset when resetAfterMs is zero', async () => {
+    const { result } = renderHook(() => useClipboard({ resetAfterMs: 0 }));
+
+    await act(async () => {
+      await result.current.copy('persist');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+
+    expect(result.current.copied).toBe(true);
+  });
+
+  it('falls back to execCommand when async API is unavailable', async () => {
+    delete (navigator as Navigator & { clipboard?: unknown }).clipboard;
+    const execMock = jest.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execMock,
+    });
+
+    const { result } = renderHook(() => useClipboard());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.copy('fallback');
+    });
+
+    expect(ok).toBe(true);
+    expect(execMock).toHaveBeenCalledWith('copy');
+    expect(result.current.copied).toBe(true);
+    expect(result.current.value).toBe('fallback');
+
+    delete (document as Document & { execCommand?: unknown }).execCommand;
+  });
+
+  it('reports an error and calls onError when both strategies fail', async () => {
+    writeTextMock.mockRejectedValueOnce(new Error('blocked'));
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: jest.fn().mockReturnValue(false),
+    });
+    const onError = jest.fn();
+
+    const { result } = renderHook(() => useClipboard({ onError }));
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.copy('nope');
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.copied).toBe(false);
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    delete (document as Document & { execCommand?: unknown }).execCommand;
+  });
+
+  it('reset() clears state and pending timers', async () => {
+    const { result } = renderHook(() => useClipboard({ resetAfterMs: 1000 }));
+
+    await act(async () => {
+      await result.current.copy('a');
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.copied).toBe(false);
+    expect(result.current.value).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    // ensure the previously scheduled timer cannot resurrect copied=true
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+});

--- a/src/react/hooks/useClipboard.ts
+++ b/src/react/hooks/useClipboard.ts
@@ -1,0 +1,145 @@
+/**
+ * Clipboard hook for copying text values (addresses, IDs, tx hashes, ...).
+ *
+ * The hook prefers the asynchronous `navigator.clipboard` API and falls back
+ * to an off-screen `<textarea>` + `document.execCommand('copy')` when running
+ * in environments where the async API is unavailable (older browsers, insecure
+ * contexts, some embedded webviews).
+ */
+
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseClipboardOptions {
+  /**
+   * Milliseconds the `copied` flag stays `true` after a successful copy.
+   * @default 2000
+   */
+  resetAfterMs?: number;
+  /**
+   * Called whenever a copy succeeds. Receives the copied text.
+   */
+  onCopy?: (value: string) => void;
+  /**
+   * Called whenever a copy fails. Receives the underlying error.
+   */
+  onError?: (error: Error) => void;
+}
+
+export interface UseClipboardReturn {
+  /** Last value that was copied, or `null` if nothing has been copied yet. */
+  value: string | null;
+  /** `true` while inside the `resetAfterMs` window after a successful copy. */
+  copied: boolean;
+  /** Most recent error from a failed copy, or `null`. */
+  error: Error | null;
+  /** Copy a value to the clipboard. Resolves to `true` on success. */
+  copy: (value: string) => Promise<boolean>;
+  /** Clear `copied`, `value`, and `error` immediately. */
+  reset: () => void;
+}
+
+const DEFAULT_RESET_MS = 2000;
+
+const isBrowser = (): boolean =>
+  typeof window !== 'undefined' && typeof document !== 'undefined';
+
+async function writeViaAsyncApi(value: string): Promise<boolean> {
+  if (!isBrowser()) return false;
+  const clipboard = (
+    navigator as Navigator & { clipboard?: { writeText?: (s: string) => Promise<void> } }
+  ).clipboard;
+  if (!clipboard?.writeText) return false;
+  await clipboard.writeText(value);
+  return true;
+}
+
+function writeViaExecCommand(value: string): boolean {
+  if (!isBrowser()) return false;
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-1000px';
+  textarea.style.left = '-1000px';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, value.length);
+  let ok = false;
+  try {
+    ok = document.execCommand('copy');
+  } catch {
+    ok = false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+  return ok;
+}
+
+/**
+ * Copy short strings (addresses, hashes, ids) to the user's clipboard.
+ *
+ * @example
+ * ```tsx
+ * const { copy, copied } = useClipboard();
+ * <button onClick={() => copy(address)}>
+ *   {copied ? 'Copied!' : 'Copy address'}
+ * </button>
+ * ```
+ */
+export function useClipboard(options: UseClipboardOptions = {}): UseClipboardReturn {
+  const { resetAfterMs = DEFAULT_RESET_MS, onCopy, onError } = options;
+  const [value, setValue] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  const reset = useCallback(() => {
+    clearTimer();
+    setValue(null);
+    setCopied(false);
+    setError(null);
+  }, [clearTimer]);
+
+  const copy = useCallback(
+    async (next: string): Promise<boolean> => {
+      clearTimer();
+      try {
+        let ok = await writeViaAsyncApi(next);
+        if (!ok) ok = writeViaExecCommand(next);
+        if (!ok) throw new Error('Clipboard API unavailable');
+        setValue(next);
+        setCopied(true);
+        setError(null);
+        onCopy?.(next);
+        if (resetAfterMs > 0) {
+          timeoutRef.current = setTimeout(() => {
+            setCopied(false);
+            timeoutRef.current = null;
+          }, resetAfterMs);
+        }
+        return true;
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        setError(err);
+        setCopied(false);
+        onError?.(err);
+        return false;
+      }
+    },
+    [clearTimer, onCopy, onError, resetAfterMs],
+  );
+
+  return { value, copied, error, copy, reset };
+}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -54,6 +54,11 @@ export { useBalance } from './hooks/useBalance';
 export { useApprove } from './hooks/useApprove';
 export { useProviderSync } from './hooks/useProviderSync';
 export type { UseProviderSyncOptions, UseProviderSyncReturn } from './hooks/useProviderSync';
+export { useClipboard } from './hooks/useClipboard';
+export type {
+  UseClipboardOptions,
+  UseClipboardReturn,
+} from './hooks/useClipboard';
 
 // Utilities - Chains & Connectors
 export { 


### PR DESCRIPTION
## Summary

Adds a reusable `useClipboard` React hook to the SDK for copying short text values (wallet addresses, transaction hashes, listing IDs).

## API

```tsx
import { useClipboard } from "zuno-marketplace-sdk/react";

const { copy, copied, value, error, reset } = useClipboard({
  resetAfterMs: 2000,
  onCopy: (v) => analytics.track("copy", { v }),
  onError: (e) => toast.error(e.message),
});
```

Return shape: `{ value, copied, error, copy, reset }`. Options: `{ resetAfterMs, onCopy, onError }`.

## Implementation

- Prefers async `navigator.clipboard.writeText`.
- Falls back to an off-screen `<textarea>` + `document.execCommand("copy")` for older browsers / insecure contexts (file://, http://) where the async API is gated.
- `copied` flips back to `false` after `resetAfterMs` (default 2000 ms; `0` disables auto-reset).
- Cleans up its timer on unmount.

## Tests

7 new unit tests in `src/__tests__/react/useClipboard.test.tsx`:

1. Initial state is empty.
2. Successful copy sets `copied`, `value`, calls `onCopy`.
3. `copied` resets after `resetAfterMs`.
4. `resetAfterMs: 0` keeps `copied` true indefinitely.
5. Falls back to `execCommand` when async API is unavailable.
6. Reports error and calls `onError` when both strategies fail.
7. `reset()` clears state and cancels pending timers.

All 7 pass: `pnpm jest useClipboard` → 7 passed, 0 failed.

## Verification

```
pnpm jest useClipboard   # 7 pass
pnpm lint                 # 0 errors, 0 warnings
pnpm build                # tsup build success
```

Intentionally has no runtime dependencies — fully tree-shakeable from the `react` entry. Downstream apps (`zuno-marketplace-ui`, `-mini`, `-admin`) can adopt this in follow-up PRs.

---

Generated with Devin AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new React hook for clipboard functionality, enabling users to copy text with status tracking, success/error callbacks, automatic state reset, and manual reset control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunokit/zuno-marketplace-sdk/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->