### PR TITLE
feat(sdk): decimal-aware token amount helpers (parseTokenAmount / formatTokenAmount)

### DIFF
--- a/src/__tests__/utils/token-amount.test.ts
+++ b/src/__tests__/utils/token-amount.test.ts
@@ -1,0 +1,153 @@
+import {
+  parseTokenAmount,
+  formatTokenAmount,
+  formatTokenAmountCompact,
+} from "../../utils/token-amount";
+
+describe("parseTokenAmount", () => {
+  it("parses simple whole amounts at common decimal counts", () => {
+    expect(parseTokenAmount("1", 18)).toBe(10n ** 18n);
+    expect(parseTokenAmount("1", 6)).toBe(1_000_000n);
+    expect(parseTokenAmount("1", 8)).toBe(100_000_000n);
+    expect(parseTokenAmount("1", 0)).toBe(1n);
+  });
+
+  it("parses fractional amounts", () => {
+    expect(parseTokenAmount("1.5", 6)).toBe(1_500_000n);
+    expect(parseTokenAmount("0.123456", 6)).toBe(123_456n);
+    expect(parseTokenAmount("0.000001", 6)).toBe(1n);
+  });
+
+  it("parses zero in several spellings", () => {
+    expect(parseTokenAmount("0", 18)).toBe(0n);
+    expect(parseTokenAmount("0.0", 18)).toBe(0n);
+    expect(parseTokenAmount("0.000000000000000000", 18)).toBe(0n);
+  });
+
+  it("preserves precision way beyond Number.MAX_SAFE_INTEGER", () => {
+    expect(parseTokenAmount("123456789012345.678901234567890123", 18)).toBe(
+      123456789012345_678901234567890123n,
+    );
+  });
+
+  it("handles a leading +/- sign", () => {
+    expect(parseTokenAmount("+1.5", 6)).toBe(1_500_000n);
+    expect(parseTokenAmount("-1.5", 6)).toBe(-1_500_000n);
+  });
+
+  it("trims leading zeros on the whole part", () => {
+    expect(parseTokenAmount("000123.45", 6)).toBe(123_450_000n);
+    expect(parseTokenAmount("0000000", 18)).toBe(0n);
+  });
+
+  it("rejects more fractional digits than the token supports", () => {
+    expect(() => parseTokenAmount("1.1234567", 6)).toThrow(
+      /more than 6 fractional digits/,
+    );
+  });
+
+  it("rejects non-numeric, empty, and malformed input", () => {
+    expect(() => parseTokenAmount("", 18)).toThrow(/empty/);
+    expect(() => parseTokenAmount("   ", 18)).toThrow(/empty/);
+    expect(() => parseTokenAmount("abc", 18)).toThrow(/invalid number format/);
+    expect(() => parseTokenAmount("1.2.3", 18)).toThrow(/invalid number format/);
+    expect(() => parseTokenAmount("1e6", 18)).toThrow(/invalid number format/);
+    expect(() =>
+      parseTokenAmount(123 as unknown as string, 18),
+    ).toThrow(/expects a string/);
+  });
+
+  it("rejects invalid decimals values", () => {
+    expect(() => parseTokenAmount("1", -1)).toThrow(/Invalid token decimals/);
+    expect(() => parseTokenAmount("1", 1.5)).toThrow(/Invalid token decimals/);
+    expect(() => parseTokenAmount("1", 100)).toThrow(/Invalid token decimals/);
+  });
+});
+
+describe("formatTokenAmount", () => {
+  it("formats common ERC-20 amounts at full precision", () => {
+    expect(formatTokenAmount(1_500_000n, { decimals: 6 })).toBe("1.5");
+    expect(formatTokenAmount(10n ** 18n, { decimals: 18 })).toBe("1");
+    expect(formatTokenAmount(1n, { decimals: 18 })).toBe("0.000000000000000001");
+  });
+
+  it("clamps display precision when displayDecimals < decimals (truncates, does not round)", () => {
+    expect(
+      formatTokenAmount(1_234_567_890_000_000_000n, {
+        decimals: 18,
+        displayDecimals: 4,
+      }),
+    ).toBe("1.2345");
+    expect(
+      formatTokenAmount(1_999_999_999_999_999_999n, {
+        decimals: 18,
+        displayDecimals: 0,
+      }),
+    ).toBe("1");
+  });
+
+  it("keeps trailing zeros when trimTrailingZeros=false", () => {
+    expect(
+      formatTokenAmount(1_500_000n, {
+        decimals: 6,
+        displayDecimals: 6,
+        trimTrailingZeros: false,
+      }),
+    ).toBe("1.500000");
+  });
+
+  it("groups thousands when groupThousands=true", () => {
+    expect(
+      formatTokenAmount(1_234_567n * 10n ** 18n, {
+        decimals: 18,
+        displayDecimals: 0,
+        groupThousands: true,
+      }),
+    ).toBe("1,234,567");
+  });
+
+  it("formats negative amounts and zero correctly", () => {
+    expect(formatTokenAmount(-1_500_000n, { decimals: 6 })).toBe("-1.5");
+    expect(formatTokenAmount(0n, { decimals: 18 })).toBe("0");
+  });
+
+  it("rejects out-of-range displayDecimals", () => {
+    expect(() =>
+      formatTokenAmount(1n, { decimals: 6, displayDecimals: -1 }),
+    ).toThrow();
+    expect(() =>
+      formatTokenAmount(1n, { decimals: 6, displayDecimals: 7 }),
+    ).toThrow();
+  });
+});
+
+describe("formatTokenAmountCompact", () => {
+  it("uses no suffix below 1000", () => {
+    expect(formatTokenAmountCompact(1_500_000n, { decimals: 6 })).toBe("1.5");
+    expect(formatTokenAmountCompact(0n, { decimals: 6 })).toBe("0");
+  });
+
+  it("uses k suffix for thousands", () => {
+    expect(
+      formatTokenAmountCompact(2_500n * 10n ** 6n, { decimals: 6 }),
+    ).toBe("2.5k");
+  });
+
+  it("uses M suffix for millions", () => {
+    expect(
+      formatTokenAmountCompact(2_500_000n * 10n ** 6n, { decimals: 6 }),
+    ).toBe("2.5M");
+  });
+
+  it("uses B suffix for billions", () => {
+    expect(
+      formatTokenAmountCompact(7_300_000_000n * 10n ** 6n, { decimals: 6 }),
+    ).toBe("7.3B");
+  });
+
+  it("respects negative amounts", () => {
+    expect(
+      formatTokenAmountCompact(-2_500_000n * 10n ** 6n, { decimals: 6 }),
+    ).toBe("-2.5M");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,12 @@ export type * from './types/api';
 export type * from './types/contracts';
 
 // Utils
+export {
+  parseTokenAmount,
+  formatTokenAmount,
+  formatTokenAmountCompact,
+} from './utils/token-amount';
+export type { FormatTokenAmountOptions } from './utils/token-amount';
 export { ZunoSDKError, ErrorCodes } from './utils/errors';
 export type { ErrorContext, ErrorCode } from './utils/errors';
 export { TransactionManager } from './utils/transactions';

--- a/src/utils/token-amount.ts
+++ b/src/utils/token-amount.ts
@@ -1,0 +1,189 @@
+/**
+ * Token amount helpers.
+ *
+ * The existing `toWei` / `fromWei` helpers only handle 18-decimal ETH.
+ * Anything ERC-20 (USDC=6, USDT=6, WBTC=8, custom marketplace tokens)
+ * needs decimal-aware conversion that doesn't lose precision. These
+ * helpers are pure, dependency-free, and return `bigint` for the integer
+ * side so callers never accidentally drop precision through Number.
+ */
+
+const MAX_DECIMALS = 36; // matches viem's safety upper bound
+
+function assertDecimals(decimals: number): void {
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > MAX_DECIMALS) {
+    throw new Error(
+      `Invalid token decimals: ${decimals}. Must be an integer in [0, ${MAX_DECIMALS}].`,
+    );
+  }
+}
+
+/**
+ * Parses a human-readable token amount (e.g. "1.5", "0.000001") into the
+ * integer "base unit" representation for a token with `decimals` precision.
+ *
+ *   parseTokenAmount("1.5", 6)   // 1_500_000n  (USDC)
+ *   parseTokenAmount("1", 18)    // 10n ** 18n  (ETH/most ERC-20)
+ *
+ * Throws on invalid input; never silently truncates excess fractional
+ * digits (excess precision is an error, not a rounding hint).
+ */
+export function parseTokenAmount(value: string, decimals: number): bigint {
+  assertDecimals(decimals);
+
+  if (typeof value !== "string") {
+    throw new Error("parseTokenAmount expects a string value");
+  }
+
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    throw new Error("parseTokenAmount: value is empty");
+  }
+
+  // Allow an optional leading sign.
+  const sign = trimmed.startsWith("-") ? -1n : 1n;
+  const unsigned = trimmed.replace(/^[+-]/, "");
+
+  if (!/^\d+(\.\d+)?$/.test(unsigned)) {
+    throw new Error(`parseTokenAmount: invalid number format: ${value}`);
+  }
+
+  const [whole, fraction = ""] = unsigned.split(".");
+
+  if (fraction.length > decimals) {
+    throw new Error(
+      `parseTokenAmount: ${value} has more than ${decimals} fractional digits`,
+    );
+  }
+
+  const padded = fraction.padEnd(decimals, "0");
+  // strip leading zeros from the whole part so '0000000' parses to 0n cleanly
+  const wholeNormalized = whole.replace(/^0+(?=\d)/, "");
+  const combined = `${wholeNormalized}${padded}`;
+  const result = BigInt(combined === "" ? "0" : combined);
+
+  return sign * result;
+}
+
+export interface FormatTokenAmountOptions {
+  /** Number of decimals the on-chain token uses (e.g. 18 for ETH, 6 for USDC). */
+  decimals: number;
+  /**
+   * Maximum number of fractional digits to render. Defaults to `decimals`
+   * (i.e. full precision). Excess precision is trimmed from the right.
+   */
+  displayDecimals?: number;
+  /**
+   * Strip trailing zeros after the decimal point. Default: true. With
+   * `displayDecimals=6`, `1.500000` formats as `1.5`.
+   */
+  trimTrailingZeros?: boolean;
+  /**
+   * Insert `,` thousands separators on the whole-number side. Default: false.
+   */
+  groupThousands?: boolean;
+}
+
+/**
+ * Formats a `bigint` base-unit amount into a human-readable string. Pure
+ * string math — no Number, no floating-point conversion at any step.
+ *
+ *   formatTokenAmount(1_500_000n, { decimals: 6 })             // "1.5"
+ *   formatTokenAmount(10n ** 18n, { decimals: 18, displayDecimals: 4 }) // "1"
+ *   formatTokenAmount(1_234_567_890_000_000_000n, {
+ *     decimals: 18,
+ *     displayDecimals: 4,
+ *     groupThousands: true,
+ *   })  // "1.2345"  (whole part has no thousands here)
+ */
+export function formatTokenAmount(
+  value: bigint,
+  options: FormatTokenAmountOptions,
+): string {
+  const {
+    decimals,
+    displayDecimals = decimals,
+    trimTrailingZeros = true,
+    groupThousands = false,
+  } = options;
+  assertDecimals(decimals);
+  if (
+    !Number.isInteger(displayDecimals) ||
+    displayDecimals < 0 ||
+    displayDecimals > decimals
+  ) {
+    throw new Error(
+      `formatTokenAmount: displayDecimals must be an integer in [0, ${decimals}]`,
+    );
+  }
+
+  const isNegative = value < 0n;
+  const abs = isNegative ? -value : value;
+
+  const raw = abs.toString().padStart(decimals + 1, "0");
+  let whole = raw.slice(0, raw.length - decimals);
+  let fraction = raw.slice(raw.length - decimals);
+
+  // Truncate fraction to displayDecimals digits (no rounding — financial
+  // amounts shouldn't be rounded for display by accident).
+  fraction = fraction.slice(0, displayDecimals);
+
+  if (trimTrailingZeros) {
+    fraction = fraction.replace(/0+$/, "");
+  }
+
+  if (groupThousands) {
+    whole = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  }
+
+  const body = fraction.length > 0 ? `${whole}.${fraction}` : whole;
+  return isNegative ? `-${body}` : body;
+}
+
+/**
+ * Best-effort short formatter for token amounts — useful for table /
+ * marquee cells where space is limited. Uses k/M/B suffixes for the
+ * whole part once it exceeds 4 digits.
+ *
+ *   formatTokenAmountCompact(1_500_000n,        { decimals: 6 })  // "1.5"
+ *   formatTokenAmountCompact(2_500_000_000_000n,{ decimals: 6 })  // "2.5M"
+ */
+export function formatTokenAmountCompact(
+  value: bigint,
+  options: FormatTokenAmountOptions,
+): string {
+  const full = formatTokenAmount(value, {
+    ...options,
+    groupThousands: false,
+    trimTrailingZeros: false,
+  });
+  const isNegative = full.startsWith("-");
+  const unsigned = isNegative ? full.slice(1) : full;
+  const [whole, fraction = ""] = unsigned.split(".");
+
+  const wholeNum = whole.replace(/^0+(?=\d)/, "") || "0";
+  const wholeBn = BigInt(wholeNum);
+
+  const suffixes: { threshold: bigint; suffix: string }[] = [
+    { threshold: 1_000_000_000n, suffix: "B" },
+    { threshold: 1_000_000n, suffix: "M" },
+    { threshold: 1_000n, suffix: "k" },
+  ];
+
+  for (const { threshold, suffix } of suffixes) {
+    if (wholeBn >= threshold) {
+      const scaled = wholeBn * 100n / threshold; // 2 decimal places, no rounding
+      const scaledStr = scaled.toString().padStart(3, "0");
+      const head = scaledStr.slice(0, -2);
+      const tail = scaledStr.slice(-2).replace(/0+$/, "");
+      const body = tail.length > 0 ? `${head}.${tail}` : head;
+      return `${isNegative ? "-" : ""}${body}${suffix}`;
+    }
+  }
+
+  // Below 1000 — return up to 2 fractional digits, trim trailing zeros.
+  const trimmedFraction = fraction.slice(0, 2).replace(/0+$/, "");
+  const body =
+    trimmedFraction.length > 0 ? `${wholeNum}.${trimmedFraction}` : wholeNum;
+  return `${isNegative ? "-" : ""}${body}`;
+}


### PR DESCRIPTION
## Summary

The existing `toWei` / `fromWei` helpers only handle 18-decimal ETH. ERC-20 tokens used by the marketplace can be 6 (USDC/USDT), 8 (WBTC), or any custom value, so consumers were either dropping precision through `Number` or rolling their own `ethers.parseUnits` wrapper at every call-site. This PR adds a pure, dependency-free decimal-aware family that operates on `bigint` base units and never touches floating-point.

## What ships

`src/utils/token-amount.ts`:

```ts
export function parseTokenAmount(value: string, decimals: number): bigint
export function formatTokenAmount(
  value: bigint,
  options: FormatTokenAmountOptions,
): string
export function formatTokenAmountCompact(
  value: bigint,
  options: FormatTokenAmountOptions,
): string
```

Key properties:

- **No precision loss**: every step is `bigint` + string math; no `Number`, no `parseFloat`.
- **No silent rounding**: `formatTokenAmount` truncates excess fractional digits rather than rounding — financial amounts shouldn't round by accident.
- **Strict input validation**: rejects scientific notation, multi-dot input, non-string input, more fractional digits than the token supports, invalid `decimals`.
- **Display options**: `displayDecimals`, `trimTrailingZeros` (default true), `groupThousands` (default false).
- **Compact formatter**: `formatTokenAmountCompact` returns `1.5k` / `2.5M` / `7.3B` for table cells — useful for activity feeds and stat cards.

`src/index.ts` re-exports the new helpers and the `FormatTokenAmountOptions` type alongside the existing utilities.

## Tests

`src/__tests__/utils/token-amount.test.ts` — **20 / 20 pass** with Jest:

- parses USDC (6), ETH (18), WBTC (8), and 0-decimals tokens
- preserves precision beyond `Number.MAX_SAFE_INTEGER` (24-digit values)
- handles leading `+` / `-` signs, leading zeros, '0.0' spellings
- rejects excess fractional digits, scientific notation, multi-dot, NaN, non-string input, invalid `decimals`
- formats with full precision, with `displayDecimals` clamp, with `groupThousands`, with `trimTrailingZeros=false`
- compact formatter: no suffix below 1000, then `k` / `M` / `B`, plus negative-amount handling

## Verification

```
pnpm type-check  # clean
pnpm lint        # clean
pnpm test src/__tests__/utils/token-amount.test.ts  # 20/20
```

---

Generated with Devin AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Token amount parsing and formatting utilities now available
  * Support for compact display with k/M/B suffixes for space-constrained layouts
  * Configurable decimal precision and optional thousand grouping

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunokit/zuno-marketplace-sdk/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->