### PR TITLE
feat(hooks): useFloorPrice + pure computeFloorPrice helper

### DIFF
--- a/src/__tests__/utils/floor-price.test.ts
+++ b/src/__tests__/utils/floor-price.test.ts
@@ -1,0 +1,148 @@
+import { computeFloorPrice } from '../../utils/floor-price';
+import type { Listing } from '../../types/entities';
+
+const ETH = '0x0000000000000000000000000000000000000000';
+const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+
+function listing(overrides: Partial<Listing> = {}): Listing {
+  return {
+    id: 'listing-1',
+    seller: '0xseller',
+    collectionAddress: '0xcoll',
+    tokenId: '1',
+    price: '1.0',
+    paymentToken: ETH,
+    startTime: 0,
+    endTime: 0,
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Listing;
+}
+
+describe('computeFloorPrice', () => {
+  it('returns null floor for empty input', () => {
+    const result = computeFloorPrice([], { now: 1_000 });
+    expect(result.floor).toBeNull();
+    expect(result.activeCount).toBe(0);
+    expect(result.byPaymentToken).toEqual({});
+  });
+
+  it('returns the cheapest active listing as floor', () => {
+    const items = [
+      listing({ id: 'a', price: '2.5' }),
+      listing({ id: 'b', price: '0.75' }),
+      listing({ id: 'c', price: '1.0' }),
+    ];
+    const result = computeFloorPrice(items, { now: 1_000 });
+    expect(result.floor?.id).toBe('b');
+    expect(result.activeCount).toBe(3);
+  });
+
+  it('compares decimal-string prices precisely (no float collapse)', () => {
+    const items = [
+      listing({ id: 'a', price: '0.100000000000000001' }), // 1.000...01e-1
+      listing({ id: 'b', price: '0.100000000000000002' }),
+      listing({ id: 'c', price: '0.100000000000000000' }),
+    ];
+    const result = computeFloorPrice(items, { now: 1_000 });
+    expect(result.floor?.id).toBe('c');
+  });
+
+  it('skips non-active statuses', () => {
+    const items = [
+      listing({ id: 'a', price: '0.5', status: 'cancelled' }),
+      listing({ id: 'b', price: '0.6', status: 'sold' }),
+      listing({ id: 'c', price: '1.0', status: 'active' }),
+    ];
+    const result = computeFloorPrice(items, { now: 1_000 });
+    expect(result.floor?.id).toBe('c');
+    expect(result.activeCount).toBe(1);
+  });
+
+  it('skips listings not yet in window (startTime > now)', () => {
+    const items = [
+      listing({ id: 'a', price: '0.5', startTime: 2_000 }),
+      listing({ id: 'b', price: '1.0' }),
+    ];
+    const result = computeFloorPrice(items, { now: 1_000 });
+    expect(result.floor?.id).toBe('b');
+  });
+
+  it('skips listings past their endTime (endTime <= now)', () => {
+    const items = [
+      listing({ id: 'a', price: '0.5', endTime: 999 }),
+      listing({ id: 'b', price: '1.0' }),
+    ];
+    const result = computeFloorPrice(items, { now: 1_000 });
+    expect(result.floor?.id).toBe('b');
+  });
+
+  it('endTime=0 means "no expiry"', () => {
+    const items = [
+      listing({ id: 'a', price: '0.5', endTime: 0 }),
+      listing({ id: 'b', price: '1.0', endTime: 9_999_999 }),
+    ];
+    const result = computeFloorPrice(items, { now: 1_000 });
+    expect(result.floor?.id).toBe('a');
+  });
+
+  it('buckets per payment token in byPaymentToken', () => {
+    const items = [
+      listing({ id: 'eth-1', price: '1.0', paymentToken: ETH }),
+      listing({ id: 'eth-2', price: '0.8', paymentToken: ETH }),
+      listing({ id: 'usdc-1', price: '0.6', paymentToken: USDC }),
+    ];
+    const result = computeFloorPrice(items, { now: 1_000 });
+    expect(result.floor?.id).toBe('usdc-1'); // absolute min across tokens
+    expect(result.byPaymentToken[ETH].id).toBe('eth-2');
+    expect(result.byPaymentToken[USDC.toLowerCase()].id).toBe('usdc-1');
+  });
+
+  it('filters to a single payment token when requested', () => {
+    const items = [
+      listing({ id: 'eth-1', price: '1.0', paymentToken: ETH }),
+      listing({ id: 'eth-2', price: '0.8', paymentToken: ETH }),
+      listing({ id: 'usdc-1', price: '0.6', paymentToken: USDC }),
+    ];
+    const result = computeFloorPrice(items, {
+      now: 1_000,
+      paymentToken: ETH,
+    });
+    expect(result.floor?.id).toBe('eth-2');
+    expect(result.activeCount).toBe(2);
+    expect(Object.keys(result.byPaymentToken)).toEqual([ETH]);
+  });
+
+  it('normalizes payment token addresses case-insensitively', () => {
+    const items = [
+      listing({ id: 'a', price: '1.0', paymentToken: ETH.toUpperCase() }),
+      listing({ id: 'b', price: '0.5', paymentToken: ETH }),
+    ];
+    const result = computeFloorPrice(items, {
+      now: 1_000,
+      paymentToken: ETH.toUpperCase(),
+    });
+    expect(result.floor?.id).toBe('b');
+    expect(result.activeCount).toBe(2);
+  });
+
+  it('skips malformed prices without throwing', () => {
+    const items = [
+      listing({ id: 'a', price: 'not-a-number' }),
+      listing({ id: 'b', price: '-1.0' }),
+      listing({ id: 'c', price: '' }),
+      listing({ id: 'd', price: '1.5' }),
+    ];
+    const result = computeFloorPrice(items, { now: 1_000 });
+    expect(result.floor?.id).toBe('d');
+    expect(result.activeCount).toBe(1);
+  });
+
+  it('returns the listing reference unchanged (no copy)', () => {
+    const item = listing({ id: 'a', price: '1.0' });
+    const result = computeFloorPrice([item], { now: 1_000 });
+    expect(result.floor).toBe(item);
+    expect(result.byPaymentToken[ETH]).toBe(item);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export type * from './types/api';
 export type * from './types/contracts';
 
 // Utils
+export { computeFloorPrice } from './utils/floor-price';
+export type { FloorPriceOptions, FloorPriceResult } from './utils/floor-price';
 export { ZunoSDKError, ErrorCodes } from './utils/errors';
 export type { ErrorContext, ErrorCode } from './utils/errors';
 export { TransactionManager } from './utils/transactions';

--- a/src/react/hooks/useFloorPrice.ts
+++ b/src/react/hooks/useFloorPrice.ts
@@ -1,0 +1,96 @@
+/**
+ * Floor price hook.
+ *
+ * Wraps the existing useListings query and reduces the result through
+ * the pure `computeFloorPrice` helper. Returns a stable, memoized
+ * result that consumers can render directly without recomputing.
+ */
+
+'use client';
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { useZuno } from '../provider/ZunoContextProvider';
+import { listingsByCollectionQueryOptions } from '../../lib/query/exchange';
+import {
+  computeFloorPrice,
+  type FloorPriceOptions,
+  type FloorPriceResult,
+} from '../../utils/floor-price';
+import type { Listing } from '../../types/entities';
+
+export interface UseFloorPriceOptions extends FloorPriceOptions {
+  /**
+   * When false, the underlying listings query is disabled and the
+   * hook returns `floor: null, activeCount: 0`. Use this to gate
+   * fetches on user input or feature flags.
+   */
+  enabled?: boolean;
+}
+
+export interface UseFloorPriceResult {
+  /** True while the underlying listings query is loading or fetching. */
+  isLoading: boolean;
+  isFetching: boolean;
+  /** Error from the underlying listings query, if any. */
+  error: Error | null;
+  /** Floor-price reduction over the active listings. */
+  data: FloorPriceResult;
+  /** Raw listings used to compute the floor. */
+  listings: Listing[];
+  /** Re-fetch the underlying listings query. */
+  refetch: () => void;
+}
+
+/**
+ * Returns the floor price of a collection.
+ *
+ * The hook fetches all listings for `collectionAddress` (via the
+ * existing `useListings` query) and reduces them with `computeFloorPrice`.
+ * The reduction is memoized so reads from the consumer component don't
+ * recompute on unrelated re-renders.
+ *
+ * Example:
+ *
+ *   const { data, isLoading } = useFloorPrice("0x…", {
+ *     paymentToken: ETH_ADDRESS,
+ *   });
+ *   if (!isLoading && data.floor) {
+ *     console.log("Floor:", data.floor.price, data.floor.paymentToken);
+ *   }
+ */
+export function useFloorPrice(
+  collectionAddress: string | undefined,
+  options: UseFloorPriceOptions = {},
+): UseFloorPriceResult {
+  const sdk = useZuno();
+  const { enabled = true, now, paymentToken } = options;
+
+  const queryOpts = listingsByCollectionQueryOptions(sdk, collectionAddress);
+  const query = useQuery({
+    ...queryOpts,
+    enabled: enabled && !!collectionAddress,
+  });
+
+  const listings: Listing[] = useMemo(
+    () => query.data ?? [],
+    [query.data],
+  );
+
+  const data: FloorPriceResult = useMemo(
+    () => computeFloorPrice(listings, { now, paymentToken }),
+    [listings, now, paymentToken],
+  );
+
+  return {
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: (query.error as Error | null) ?? null,
+    data,
+    listings,
+    refetch: () => {
+      void query.refetch();
+    },
+  };
+}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -20,6 +20,8 @@ export { useZunoLogger } from './hooks/useZunoLogger';
 
 // Hooks - Exchange
 export { useExchange, useListings, useListingsBySeller, useListing } from './hooks/useExchange';
+export { useFloorPrice } from './hooks/useFloorPrice';
+export type { UseFloorPriceOptions, UseFloorPriceResult } from './hooks/useFloorPrice';
 
 // Hooks - Collection
 export { 

--- a/src/utils/floor-price.ts
+++ b/src/utils/floor-price.ts
@@ -1,0 +1,143 @@
+/**
+ * Floor price computation from a list of NFT listings.
+ *
+ * The floor price of a collection is the lowest "active" listing
+ * price denominated in the collection's payment token. Several
+ * decisions matter here:
+ *
+ *   - Only `active` listings count. `pending`, `sold`, `cancelled`,
+ *     `expired` listings are excluded.
+ *   - Listings with `startTime > now` or `endTime <= now` are
+ *     considered out-of-window and excluded.
+ *   - Floor is computed per payment token. A collection that has
+ *     ETH listings and USDC listings has two floors; the helper
+ *     returns the lowest by sortable string magnitude per token.
+ *   - The `price` field on Listing is a decimal string in ETH/units
+ *     (not wei). The helper compares using bigint scaled by 10^18
+ *     so we never lose precision to floating point.
+ *
+ * The helper is pure: input -> output, no fetch, no Date.now
+ * besides the explicit `now` parameter. That keeps it trivially
+ * testable.
+ */
+
+import type { Listing } from '../types/entities';
+
+const SCALE = 10n ** 18n;
+
+export interface FloorPriceOptions {
+  /**
+   * Override the "now" timestamp (Unix seconds) used to drop
+   * out-of-window listings. Defaults to `Math.floor(Date.now()/1000)`.
+   */
+  now?: number;
+  /**
+   * Only consider listings paid in this payment token (address or
+   * `null` for the native asset). When omitted, all payment tokens
+   * are bucketed and `byPaymentToken` contains the per-token floors.
+   */
+  paymentToken?: string | null;
+}
+
+export interface FloorPriceResult {
+  /**
+   * Lowest active listing across all considered payment tokens.
+   * Null when there are no valid listings.
+   */
+  floor: Listing | null;
+  /**
+   * Number of active in-window listings considered.
+   */
+  activeCount: number;
+  /**
+   * Per-payment-token floor listing.
+   */
+  byPaymentToken: Record<string, Listing>;
+}
+
+function normalizePayment(token: string): string {
+  return token.toLowerCase();
+}
+
+/**
+ * Parse a decimal-string price (e.g. "1.25") into a scaled bigint
+ * (1.25e18). Returns null on malformed input so the helper never
+ * throws on a single bad row.
+ */
+function priceToScaled(price: string): bigint | null {
+  if (typeof price !== 'string' || price.length === 0) return null;
+  const trimmed = price.trim();
+  if (!/^-?\d+(\.\d+)?$/.test(trimmed)) return null;
+  if (trimmed.startsWith('-')) return null;
+
+  const [whole, frac = ''] = trimmed.split('.');
+  if (frac.length > 18) return null; // we don't preserve sub-wei precision
+  const padded = frac.padEnd(18, '0');
+  try {
+    return BigInt(whole) * SCALE + BigInt(padded);
+  } catch {
+    return null;
+  }
+}
+
+function isActiveInWindow(listing: Listing, now: number): boolean {
+  if (listing.status !== 'active') return false;
+  if (listing.startTime > now) return false;
+  if (listing.endTime > 0 && listing.endTime <= now) return false;
+  return true;
+}
+
+/**
+ * Computes the floor price of a collection given a list of listings.
+ *
+ * - When `paymentToken` is provided, only listings paid in that
+ *   token are considered and `floor` is the global minimum.
+ * - When `paymentToken` is omitted, listings are bucketed per
+ *   payment token in `byPaymentToken`; `floor` is the absolute
+ *   minimum across all buckets (still a useful single answer for
+ *   ETH-dominant collections, but consumers should also surface
+ *   `byPaymentToken` when multiple buckets exist).
+ */
+export function computeFloorPrice(
+  listings: readonly Listing[],
+  options: FloorPriceOptions = {},
+): FloorPriceResult {
+  const now = options.now ?? Math.floor(Date.now() / 1000);
+  const requested = options.paymentToken
+    ? normalizePayment(options.paymentToken)
+    : null;
+
+  let globalMin: { listing: Listing; scaled: bigint } | null = null;
+  const perToken = new Map<string, { listing: Listing; scaled: bigint }>();
+  let activeCount = 0;
+
+  for (const listing of listings) {
+    if (!isActiveInWindow(listing, now)) continue;
+    const token = normalizePayment(listing.paymentToken);
+    if (requested !== null && token !== requested) continue;
+
+    const scaled = priceToScaled(listing.price);
+    if (scaled === null) continue;
+
+    activeCount += 1;
+
+    if (globalMin === null || scaled < globalMin.scaled) {
+      globalMin = { listing, scaled };
+    }
+    const bucket = perToken.get(token);
+    if (!bucket || scaled < bucket.scaled) {
+      perToken.set(token, { listing, scaled });
+    }
+  }
+
+  const byPaymentToken: Record<string, Listing> = {};
+  for (const [token, entry] of perToken.entries()) {
+    byPaymentToken[token] = entry.listing;
+  }
+
+  return {
+    floor: globalMin ? globalMin.listing : null,
+    activeCount,
+    byPaymentToken,
+  };
+}


### PR DESCRIPTION
## Summary

Floor price is one of the most-rendered metrics on every collection page. Today consumers either roll their own reduction over the listings query, or are forced to call a downstream API.

This PR adds **both layers**:

1. **Pure reducer** (`src/utils/floor-price.ts`) — takes `Listing[]` and returns the floor + per-payment-token bucket. No fetch, no globals — trivially unit-testable and reusable in non-React contexts (Node scripts, indexer aggregations, server components).
2. **React hook** (`src/react/hooks/useFloorPrice.ts`) — wraps the existing `useListings` TanStack Query and memoizes the reduction. Re-runs only when listings, now, or paymentToken actually change.

## Decisions baked into the reducer

- Only `active` listings count. `pending` / `sold` / `cancelled` / `expired` are excluded.
- Listings with `startTime > now` or `endTime <= now` are skipped.
- Decimal-string prices are compared via **bigint scaled by 1e18**, so `0.100000000000000001` < `0.100000000000000002` resolves correctly without float collapse.
- Per-payment-token buckets (`byPaymentToken`) so multi-currency collections can render an honest "cheapest in ETH / cheapest in USDC" UI. The top-level `floor` is the absolute minimum across buckets.
- Malformed price strings are skipped silently rather than throwing — one bad row should not invalidate the entire feed.

## Public exports

```ts
// from '@zuno/sdk'
import { computeFloorPrice, type FloorPriceResult } from '@zuno/sdk';

// from '@zuno/sdk/react'
import { useFloorPrice } from '@zuno/sdk/react';

const { data, isLoading } = useFloorPrice('0x…', { paymentToken: ETH });
if (data.floor) console.log('Floor:', data.floor.price);
```

## Tests (`src/__tests__/utils/floor-price.test.ts`) — **12 / 12 pass**

- empty input → null floor
- cheapest active listing wins
- decimal-precision comparison (no float collapse)
- non-active statuses skipped
- `startTime > now` skipped
- `endTime <= now` skipped
- `endTime=0` = no expiry
- `byPaymentToken` bucketing
- `paymentToken` filter restricts the search
- case-insensitive payment token matching
- malformed prices skipped without throwing
- returns original `Listing` reference (no copy)

## Verification

```
pnpm test --testPathPattern=floor-price  # 12/12
pnpm type-check                          # clean
pnpm lint                                # clean
```

---

Generated with Devin AI